### PR TITLE
fix: 解析執行檔 symlink，修正安裝後在任意目錄啟動找不到 static 目錄

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -73,7 +73,11 @@ pub fn find_resource(relative: impl AsRef<Path>) -> Option<PathBuf> {
         // ~/.local/bin 內是指向安裝目錄的 symlink；先解析 symlink 才能找到
         // 與真實執行檔同層的資源目錄。
         let resolved = std::fs::canonicalize(&executable).unwrap_or_else(|_| executable.clone());
-        for exe in [&resolved, &executable] {
+        let mut exes = vec![&resolved];
+        if resolved != executable {
+            exes.push(&executable);
+        }
+        for exe in exes {
             if let Some(executable_dir) = exe.parent() {
                 roots.extend(executable_dir.ancestors().take(5).map(Path::to_path_buf));
             }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -70,8 +70,13 @@ pub fn find_resource(relative: impl AsRef<Path>) -> Option<PathBuf> {
         roots.push(PathBuf::from(manifest_dir));
     }
     if let Ok(executable) = std::env::current_exe() {
-        if let Some(executable_dir) = executable.parent() {
-            roots.extend(executable_dir.ancestors().take(5).map(Path::to_path_buf));
+        // ~/.local/bin 內是指向安裝目錄的 symlink；先解析 symlink 才能找到
+        // 與真實執行檔同層的資源目錄。
+        let resolved = std::fs::canonicalize(&executable).unwrap_or_else(|_| executable.clone());
+        for exe in [&resolved, &executable] {
+            if let Some(executable_dir) = exe.parent() {
+                roots.extend(executable_dir.ancestors().take(5).map(Path::to_path_buf));
+            }
         }
     }
     if let Ok(current_dir) = std::env::current_dir() {


### PR DESCRIPTION
## 問題

使用 `scripts/get.sh` 一行安裝後（macOS 26.5, Apple Silicon, v0.1.5），在任意目錄執行：

```
PORT=3003 ~/.local/bin/token-usage-insights
```

會得到：

```
✅ SQLite 資料庫已成功載入並完成增量同步！
❌ 無法定位 static 目錄。請在專案根目錄下執行此程式。
```

並以 exit code 1 結束。先 `cd ~/.local/share/token-usage-insights` 再執行則正常。

## 根因

`install.sh` 會把真正的執行檔與 `static/` 放在 `~/.local/share/token-usage-insights/`，而 `~/.local/bin/token-usage-insights` 只是指向它的 **symlink**。`src/paths.rs` 的 `find_resource()` 雖然已使用 `std::env::current_exe()`，但透過 symlink 啟動時回傳的是 `~/.local/bin/...`，於是只會在 `~/.local/bin` 的祖先目錄找 `static/`，永遠找不到。

## 修正

在 `find_resource()` 中先以 `std::fs::canonicalize()` 解析執行檔的 symlink，改從真實執行檔所在目錄往上搜尋資源；原始（未解析）路徑仍保留為備援搜尋根，不影響既有行為。

## 測試

- 本地模擬完整安裝佈局（binary 在 `share/token-usage-insights/`、`bin/` 放 symlink），並排除原始碼目錄的干擾後，從無關目錄啟動：成功定位 `static/`，伺服器啟動，`curl /` 回 HTTP 200。
- `cargo test` 全部 15 個測試通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)