### PR TITLE
feat(server): 新增 HOST 綁定位址設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ cargo build --release --bin token-usage-insights-cli
 
 | 變數 | 預設值 | 用途 |
 | --- | --- | --- |
+| `HOST` | `0.0.0.0` | 看板服務綁定的 IPv4 或 IPv6 位址 |
 | `PORT` | `3003` | 看板服務埠號 |
 | `INSIGHTS_DIR` | Windows: `%LOCALAPPDATA%\TokenUsageInsights`; 其他平台: `~/.token-usage-insights` | SQLite 資料庫目錄 |
 | `ANTIGRAVITY_DIR` | `~/.gemini/antigravity-cli` | Antigravity CLI 資料目錄 |
@@ -362,16 +363,18 @@ cargo build --release --bin token-usage-insights-cli
 | `CURSOR_DIR` | `~/.cursor` | Cursor 資料目錄 |
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:<PORT>,http://127.0.0.1:<PORT>` | 允許的 CORS 來源，逗號分隔 |
 
+> **預設綁定 `0.0.0.0`，同一區網內的其他裝置可能連線到看板。只需在本機瀏覽時，請將 `HOST` 設為 `127.0.0.1`。**
+
 範例：
 
 ```bash
-INSIGHTS_DIR="/tmp/token-usage-insights" PORT="3010" "$HOME/.local/bin/token-usage-insights"
+HOST="127.0.0.1" INSIGHTS_DIR="/tmp/token-usage-insights" PORT="3010" "$HOME/.local/bin/token-usage-insights"
 ```
 
 Windows PowerShell 範例：
 
 ```powershell
-$env:INSIGHTS_DIR = 'D:\Token Usage Insights\資料庫'; $env:CODEX_DIR = "$env:USERPROFILE\.codex"; $env:PORT = '3010'; & "$HOME\bin\token-usage-insights.cmd"
+$env:HOST = '127.0.0.1'; $env:INSIGHTS_DIR = 'D:\Token Usage Insights\資料庫'; $env:CODEX_DIR = "$env:USERPROFILE\.codex"; $env:PORT = '3010'; & "$HOME\bin\token-usage-insights.cmd"
 ```
 
 * * *

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@ default_bin_dir="${HOME}/.local/bin"
 install_dir="${TOKEN_USAGE_INSIGHTS_INSTALL_DIR:-$default_install_dir}"
 bin_dir="${TOKEN_USAGE_INSIGHTS_BIN_DIR:-$default_bin_dir}"
 port="${PORT:-3003}"
+host="${HOST:-0.0.0.0}"
 install_service=false
 
 usage() {
@@ -17,6 +18,7 @@ Usage: ./install.sh [--service]
 Environment:
   TOKEN_USAGE_INSIGHTS_INSTALL_DIR  Install directory. Default: ${default_install_dir}
   TOKEN_USAGE_INSIGHTS_BIN_DIR      Directory for the executable link. Default: ${default_bin_dir}
+  HOST                              Dashboard bind address. Default: 0.0.0.0
   PORT                              Dashboard port. Default: 3003
 
 Options:
@@ -100,6 +102,7 @@ ExecStart=${install_dir}/${app_name}
 Restart=always
 RestartSec=5
 Environment=PORT=${port}
+Environment=HOST=${host}
 
 [Install]
 WantedBy=default.target
@@ -119,6 +122,5 @@ Executable:
   ${bin_dir}/${app_name}
 
 Run:
-  PORT=${port} ${bin_dir}/${app_name}
+  HOST=${host} PORT=${port} ${bin_dir}/${app_name}
 DONE
-

--- a/shell/token-usage-insights.service
+++ b/shell/token-usage-insights.service
@@ -8,6 +8,7 @@ WorkingDirectory=<PROJECT_DIR>
 ExecStart=<PROJECT_DIR>/target/release/token-usage-insights
 Restart=always
 RestartSec=5
+Environment=HOST=0.0.0.0
 Environment=PORT=3003
 
 [Install]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use std::path::PathBuf;
+use std::{
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+};
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 
@@ -18,6 +21,7 @@ mod vscode;
 use handlers::*;
 
 const MAX_IMPORT_PAYLOAD_BYTES: usize = 200_000_000;
+const DEFAULT_BIND_HOST: &str = "0.0.0.0";
 
 fn import_usage_route() -> axum::routing::MethodRouter {
     post(import_usage_day).layer(DefaultBodyLimit::max(MAX_IMPORT_PAYLOAD_BYTES))
@@ -64,6 +68,19 @@ fn build_cors_layer() -> CorsLayer {
         .allow_origin(allowed_origins)
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([CONTENT_TYPE])
+}
+
+fn parse_bind_address(host: &str, port: u16) -> Result<SocketAddr, String> {
+    let host = host.trim();
+    let ip_address = host
+        .parse::<IpAddr>()
+        .map_err(|_| format!("HOST 必須是有效的 IPv4 或 IPv6 位址，目前值為 {host:?}"))?;
+    Ok(SocketAddr::new(ip_address, port))
+}
+
+fn configured_bind_address(port: u16) -> Result<SocketAddr, String> {
+    let host = std::env::var("HOST").unwrap_or_else(|_| DEFAULT_BIND_HOST.to_string());
+    parse_bind_address(&host, port)
 }
 
 fn initialize_database_schema() -> Result<(), String> {
@@ -145,9 +162,17 @@ async fn main() {
         .and_then(|p| p.parse::<u16>().ok())
         .unwrap_or(3003); // 預設使用 3003 Port
 
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
+    let bind_address = configured_bind_address(port).unwrap_or_else(|error| {
+        eprintln!("❌ 無法解析服務綁定位址: {error}");
+        std::process::exit(1);
+    });
+    let listener = tokio::net::TcpListener::bind(bind_address)
         .await
-        .unwrap();
+        .unwrap_or_else(|error| {
+            eprintln!("❌ 無法綁定服務位址 {bind_address}: {error}");
+            std::process::exit(1);
+        });
+    println!("🌐 服務綁定位址: http://{}", bind_address);
     println!("🚀 Token 戰情室 is running on: http://localhost:{}", port);
 
     // HTTP 先開始監聽；可能耗時的遷移與 transcript 同步在 blocking thread 執行。
@@ -178,6 +203,26 @@ mod tests {
     #[test]
     fn import_payload_limit_is_200_megabytes() {
         assert_eq!(MAX_IMPORT_PAYLOAD_BYTES, 200_000_000);
+    }
+
+    #[test]
+    fn parse_bind_address_accepts_ipv4_and_ipv6() {
+        assert_eq!(
+            parse_bind_address("127.0.0.1", 3003).unwrap(),
+            "127.0.0.1:3003".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(
+            parse_bind_address("::1", 3003).unwrap(),
+            "[::1]:3003".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_bind_address_rejects_non_ip_host() {
+        let error = parse_bind_address("localhost", 3003).unwrap_err();
+
+        assert!(error.contains("IPv4 或 IPv6"));
+        assert!(error.contains("localhost"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,14 @@ fn configured_bind_address(port: u16) -> Result<SocketAddr, String> {
     parse_bind_address(&host, port)
 }
 
+fn browser_url_for_bind_address(bind_address: SocketAddr) -> String {
+    if bind_address.ip().is_unspecified() {
+        format!("http://localhost:{}", bind_address.port())
+    } else {
+        format!("http://{bind_address}")
+    }
+}
+
 fn initialize_database_schema() -> Result<(), String> {
     let conn = db::get_db_conn()?;
     db::init_db(&conn)
@@ -172,8 +180,11 @@ async fn main() {
             eprintln!("❌ 無法綁定服務位址 {bind_address}: {error}");
             std::process::exit(1);
         });
-    println!("🌐 服務綁定位址: http://{}", bind_address);
-    println!("🚀 Token 戰情室 is running on: http://localhost:{}", port);
+    println!("🌐 服務綁定位址: {bind_address}");
+    println!(
+        "🚀 Token 戰情室 is running on: {}",
+        browser_url_for_bind_address(bind_address)
+    );
 
     // HTTP 先開始監聽；可能耗時的遷移與 transcript 同步在 blocking thread 執行。
     spawn_usage_sync_task();
@@ -223,6 +234,30 @@ mod tests {
 
         assert!(error.contains("IPv4 或 IPv6"));
         assert!(error.contains("localhost"));
+    }
+
+    #[test]
+    fn browser_url_uses_localhost_for_unspecified_addresses() {
+        assert_eq!(
+            browser_url_for_bind_address("0.0.0.0:3003".parse().unwrap()),
+            "http://localhost:3003"
+        );
+        assert_eq!(
+            browser_url_for_bind_address("[::]:3003".parse().unwrap()),
+            "http://localhost:3003"
+        );
+    }
+
+    #[test]
+    fn browser_url_preserves_specific_ipv4_and_ipv6_addresses() {
+        assert_eq!(
+            browser_url_for_bind_address("127.0.0.1:3003".parse().unwrap()),
+            "http://127.0.0.1:3003"
+        );
+        assert_eq!(
+            browser_url_for_bind_address("[::1]:3003".parse().unwrap()),
+            "http://[::1]:3003"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 變更內容

- 新增 `HOST` 環境變數，接受 IPv4 與 IPv6 位址。
- 預設維持既有的 `0.0.0.0`，避免改變現有區網使用情境。
- 無效位址會在啟動時顯示明確錯誤，不再交由底層綁定失敗處理。
- systemd 安裝腳本與服務範本同步支援 `HOST`。
- README 明確說明預設區網可見性，並提供 `HOST=127.0.0.1` 的本機限定範例。

## 根本原因

伺服器原先將 `0.0.0.0` 寫死在 `TcpListener::bind`，使用者無法限制只監聽 loopback 介面。

## 使用者影響

只需本機使用時，可設定 `HOST=127.0.0.1`，避免同一區網的其他裝置連線；既有使用者未設定 `HOST` 時行為維持不變。

## 驗證

- `cargo test`：主程式 48 項、CLI 38 項測試通過
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release --all-targets`
- `bash -n scripts/install.sh`
- 實際以 `HOST=127.0.0.1 PORT=39112` 啟動並成功呼叫 `/api/codex/pricing`
- 驗證 `HOST=localhost` 會以明確訊息拒絕啟動

Fixes #2