### PR TITLE
fix(pricing): 新增 Claude Opus 5 費率

### DIFF
--- a/pricing.csv
+++ b/pricing.csv
@@ -34,6 +34,7 @@ Claude Sonnet 4.6,Global,1M Tokens,3.00,0.30,15.00,N/A
 Claude Sonnet 4.5,Global,1M Tokens,3.00,0.30,15.00,N/A
 Claude Haiku 4.5,Global,1M Tokens,1.00,0.10,5.00,N/A
 Claude Fable 5,Global,1M Tokens,10.00,1.00,50.00,N/A
+Claude Opus 5,Global,1M Tokens,5.00,0.50,25.00,N/A
 Claude Opus 4.8-fast,Global,1M Tokens,10.00,1.00,50.00,N/A
 Claude Opus 4.8,Global,1M Tokens,5.00,0.50,25.00,N/A
 Claude Opus 4.7,Global,1M Tokens,5.00,0.50,25.00,N/A
@@ -113,11 +114,11 @@ claude-4-sonnet,Cursor,1M Tokens,3.00,0.30,15.00,N/A
 claude-4-sonnet-1m,Cursor,1M Tokens,3.00,0.30,15.00,N/A
 claude-4-5-haiku,Cursor,1M Tokens,1.00,0.10,5.00,N/A
 claude-fable-5,Cursor,1M Tokens,10.00,1.00,50.00,N/A
+claude-opus-5,Cursor,1M Tokens,5.00,0.50,25.00,N/A
 claude-opus-4-8,Cursor,1M Tokens,5.00,0.50,25.00,N/A
 claude-opus-4-7-fast,Cursor,1M Tokens,10.00,1.00,50.00,N/A
 claude-opus-4-7,Cursor,1M Tokens,5.00,0.50,25.00,N/A
 claude-opus-4-6,Cursor,1M Tokens,5.00,0.50,25.00,N/A
 claude-opus-4-5,Cursor,1M Tokens,5.00,0.50,25.00,N/A
-
 
 

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -251,7 +251,7 @@ mod tests {
                     .unwrap();
 
             assert!(
-                (cost - 30.5).abs() < f64::EPSILON,
+                (cost - 30.5).abs() < 1e-9,
                 "unexpected Opus 5 cost for {model_name}: {cost}"
             );
         }

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -235,4 +235,25 @@ mod tests {
 
         assert!((cost - 0.068_139_3).abs() < f64::EPSILON);
     }
+
+    #[test]
+    fn claude_opus_5_variants_use_packaged_pricing() {
+        let rules = load_pricing_rules();
+
+        for model_name in [
+            "claude-opus-5",
+            "Claude Opus 5",
+            "claude-opus-5-1m · high",
+            "opus-5",
+        ] {
+            let cost =
+                calculate_usage_cost(&rules, Some(model_name), 1_000_000, 1_000_000, 1_000_000)
+                    .unwrap();
+
+            assert!(
+                (cost - 30.5).abs() < f64::EPSILON,
+                "unexpected Opus 5 cost for {model_name}: {cost}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## 變更內容

- 新增 `Claude Opus 5` Global 定價規則。
- 新增 `claude-opus-5` Cursor 定價規則。
- 加入封裝價格表整合測試，覆蓋官方模型 ID、顯示名稱、簡稱及帶後綴名稱。

## 根本原因

`pricing.csv` 沒有 Opus 5 規則；現有正規化與 contains fallback 找不到可用價格，因此整段成本估算回傳錯誤並顯示為零。

## 定價依據

Anthropic 官方模型 ID 為 `claude-opus-5`；標準價格為每百萬 Token 輸入 5 美元、快取讀取 0.5 美元、輸出 25 美元，與 Opus 4.8 相同。

- [Anthropic 模型總覽](https://platform.claude.com/docs/en/about-claude/models/overview)
- [Anthropic 定價](https://platform.claude.com/docs/en/about-claude/pricing)
- [Anthropic Fast mode](https://platform.claude.com/docs/en/build-with-claude/fast-mode)

Fast mode 仍使用相同模型 ID，速度由請求欄位表示；本 PR 不臆造額外模型名稱。

## 驗證

- `cargo test`：主程式 51 項、CLI 38 項測試通過
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release --all-targets`
- 實際呼叫 `/api/claude/pricing`，確認 Global 與 Cursor 規則均回傳 5 / 0.5 / 25
- 測試 `claude-opus-5`、`Claude Opus 5`、`claude-opus-5-1m · high`、`opus-5` 皆估算為每組 100 萬 Token 共 30.5 美元

Fixes #15