### PR TITLE
fix(pricing): 依每筆實際模型計算成本

### DIFF
--- a/src/handlers/daily.rs
+++ b/src/handlers/daily.rs
@@ -20,6 +20,16 @@ use crate::timeline::{
     parse_copilot_timeline, parse_cursor_timeline, parse_vscode_timeline, TimelineItem,
 };
 
+fn add_usage_to_day_summary(summary: &mut DaySummary, usage: &UsageAggregation) {
+    summary.total_tokens += usage.total_tokens;
+    summary.total_input_tokens += usage.input_tokens;
+    summary.total_output_tokens += usage.output_tokens;
+    summary.total_cache_read_tokens += usage.cache_read_tokens;
+    summary.total_cache_write_tokens += usage.cache_write_tokens;
+    summary.total_reasoning_tokens += usage.reasoning_tokens;
+    summary.total_cost_usd += usage.cost_usd;
+}
+
 fn is_safe_session_id(session_id: &str) -> bool {
     if session_id.is_empty() || session_id.len() > 128 {
         return false;
@@ -500,24 +510,6 @@ pub async fn get_usage_details(
     let mut session_last_entries: HashMap<String, UsageEntry> = HashMap::new();
 
     for e in &entries {
-        if let Some(ref tokens) = e.delta_tokens {
-            summary.total_tokens += tokens.total;
-            summary.total_input_tokens += tokens.input;
-            summary.total_output_tokens += tokens.output;
-            summary.total_cache_read_tokens += tokens.cache_read.unwrap_or(0);
-            summary.total_cache_write_tokens += tokens.cache_write.unwrap_or(0);
-            summary.total_reasoning_tokens += tokens.reasoning.unwrap_or(0);
-        } else if let Some(ref tokens) = e.tokens {
-            if e.turn_no == 1 {
-                summary.total_tokens += tokens.total;
-                summary.total_input_tokens += tokens.input;
-                summary.total_output_tokens += tokens.output;
-                summary.total_cache_read_tokens += tokens.cache_read.unwrap_or(0);
-                summary.total_cache_write_tokens += tokens.cache_write.unwrap_or(0);
-                summary.total_reasoning_tokens += tokens.reasoning.unwrap_or(0);
-            }
-        }
-
         let sid = e.session_id.clone();
         let last_e = session_last_entries.entry(sid).or_insert_with(|| e.clone());
         if e.turn_no > last_e.turn_no {
@@ -555,7 +547,7 @@ pub async fn get_usage_details(
         let total_cache_write_tokens = session_usage.usage.cache_write_tokens;
         let total_reasoning_tokens = session_usage.usage.reasoning_tokens;
         let cost_usd = session_usage.usage.cost_usd;
-        summary.total_cost_usd += cost_usd;
+        add_usage_to_day_summary(&mut summary, &session_usage.usage);
 
         sessions_summary.push(SessionSummary {
             session_id: session_id.clone(),
@@ -1021,6 +1013,30 @@ pub async fn get_session_details(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pricing::PricingRule;
+
+    fn legacy_usage_entry(turn_no: u32, model: &str, tokens: TokenStats) -> UsageEntry {
+        UsageEntry {
+            timestamp: format!("2026-07-10T10:{turn_no:02}:00Z"),
+            session_id: "legacy-session".to_string(),
+            session_name: None,
+            transcript_path: None,
+            cwd: None,
+            version: None,
+            turn_no,
+            model: Some(model.to_string()),
+            model_id: Some(model.to_string()),
+            tokens: Some(tokens),
+            delta_tokens: None,
+            context: None,
+            cost: None,
+            source_kind: None,
+            parent_session_id: None,
+            agent_nickname: None,
+            agent_role: None,
+            reasoning_effort: None,
+        }
+    }
 
     fn user_prompt(prompt: &str, turn_no: u32) -> TimelineItem {
         TimelineItem::UserPrompt {
@@ -1053,5 +1069,63 @@ mod tests {
         ];
 
         assert!(!timeline_matches_user_prompt(&timeline, "secret keyword"));
+    }
+
+    #[test]
+    fn day_summary_uses_last_real_cumulative_legacy_entry() {
+        let rules = [PricingRule {
+            model_name: "test-model".to_string(),
+            input_price: 1.0,
+            cache_input_price: 0.1,
+            output_price: 2.0,
+        }];
+        let entries = vec![
+            legacy_usage_entry(
+                1,
+                "test-model",
+                TokenStats {
+                    input: 100,
+                    output: 20,
+                    cache_read: Some(10),
+                    cache_write: Some(0),
+                    reasoning: Some(5),
+                    total: 135,
+                },
+            ),
+            legacy_usage_entry(
+                2,
+                "test-model",
+                TokenStats {
+                    input: 200,
+                    output: 40,
+                    cache_read: Some(20),
+                    cache_write: Some(0),
+                    reasoning: Some(10),
+                    total: 270,
+                },
+            ),
+            legacy_usage_entry(
+                3,
+                "<synthetic>",
+                TokenStats {
+                    input: 0,
+                    output: 0,
+                    cache_read: Some(0),
+                    cache_write: Some(0),
+                    reasoning: Some(0),
+                    total: 0,
+                },
+            ),
+        ];
+        let session_usage = summarize_session_usage(&rules, &entries);
+        let mut summary = DaySummary::default();
+
+        add_usage_to_day_summary(&mut summary, &session_usage.usage);
+
+        assert_eq!(summary.total_tokens, 270);
+        assert_eq!(summary.total_input_tokens, 200);
+        assert_eq!(summary.total_output_tokens, 40);
+        assert_eq!(summary.total_cache_read_tokens, 20);
+        assert_eq!(summary.total_reasoning_tokens, 10);
     }
 }

--- a/src/handlers/daily.rs
+++ b/src/handlers/daily.rs
@@ -14,7 +14,7 @@ use std::{
 
 use super::*;
 use crate::db::{self, TokenStats};
-use crate::pricing::{calculate_usage_cost, load_pricing_rules};
+use crate::pricing::load_pricing_rules;
 use crate::timeline::{
     parse_antigravity_timeline, parse_claude_timeline, parse_codex_timeline,
     parse_copilot_timeline, parse_cursor_timeline, parse_vscode_timeline, TimelineItem,
@@ -533,46 +533,7 @@ pub async fn get_usage_details(
             .get(session_id)
             .cloned()
             .unwrap_or_else(|| s_entries[0].clone());
-
-        let session_tokens = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.total).unwrap_or(0))
-            .sum::<u64>();
-        let session_input_tokens = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.input).unwrap_or(0))
-            .sum::<u64>();
-        let session_output_tokens = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.output).unwrap_or(0))
-            .sum::<u64>();
-        let session_cache_read = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.cache_read)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
-        let session_cache_write = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.cache_write)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
-        let session_reasoning = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.reasoning)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
+        let session_usage = summarize_session_usage(&pricing_rules, s_entries);
 
         let session_duration = last_entry
             .cost
@@ -588,57 +549,12 @@ pub async fn get_usage_details(
         summary.total_duration_ms += session_duration;
         summary.total_requests += session_requests;
 
-        let total_cache_read_tokens = if session_tokens > 0 {
-            session_cache_read
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.cache_read)
-                .unwrap_or(0)
-        };
-        let total_cache_write_tokens = if session_tokens > 0 {
-            session_cache_write
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.cache_write)
-                .unwrap_or(0)
-        };
-        let total_reasoning_tokens = if session_tokens > 0 {
-            session_reasoning
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.reasoning)
-                .unwrap_or(0)
-        };
-        let total_input_tokens = if session_tokens > 0 {
-            session_input_tokens
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.input).unwrap_or(0)
-        };
-        let total_output_tokens = if session_tokens > 0 {
-            session_output_tokens
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.output).unwrap_or(0)
-        };
-
-        let cost_usd = match calculate_usage_cost(
-            &pricing_rules,
-            last_entry.model.as_deref(),
-            total_input_tokens,
-            total_output_tokens,
-            total_cache_read_tokens,
-        ) {
-            Ok(v) => v,
-            Err(err) => {
-                eprintln!("⚠️ 計算成本失敗: {}", err);
-                0.0
-            }
-        };
+        let total_input_tokens = session_usage.usage.input_tokens;
+        let total_output_tokens = session_usage.usage.output_tokens;
+        let total_cache_read_tokens = session_usage.usage.cache_read_tokens;
+        let total_cache_write_tokens = session_usage.usage.cache_write_tokens;
+        let total_reasoning_tokens = session_usage.usage.reasoning_tokens;
+        let cost_usd = session_usage.usage.cost_usd;
         summary.total_cost_usd += cost_usd;
 
         sessions_summary.push(SessionSummary {
@@ -652,14 +568,8 @@ pub async fn get_usage_details(
                 .clone()
                 .unwrap_or_else(|| "legacy".to_string()),
             cwd: last_entry.cwd.unwrap_or_default(),
-            model: last_entry
-                .model
-                .unwrap_or_else(|| "Unknown Model".to_string()),
-            total_tokens: if session_tokens > 0 {
-                session_tokens
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.total).unwrap_or(0)
-            },
+            model: session_usage.display_model,
+            total_tokens: session_usage.usage.total_tokens,
             total_input_tokens,
             total_output_tokens,
             total_cache_read_tokens,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -98,7 +98,10 @@ fn record_usage(
     ) {
         Ok(cost) => cost,
         Err(error) => {
-            eprintln!("⚠️ 計算成本失敗: {}", error);
+            eprintln!(
+                "計算成本失敗: session_id={} turn_no={} model={}: {}",
+                entry.session_id, entry.turn_no, model_label, error
+            );
             0.0
         }
     };

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,4 +1,7 @@
-use crate::db::UsageEntry;
+use crate::{
+    db::{TokenStats, UsageEntry},
+    pricing::{calculate_usage_cost, PricingRule},
+};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -26,6 +29,144 @@ pub fn is_supported_assistant(assistant: &str) -> bool {
         normalize_assistant_name(assistant).as_str(),
         "antigravity" | "copilot" | "codex" | "claude" | "cursor"
     )
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct UsageAggregation {
+    pub total_tokens: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub cost_usd: f64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ModelUsageAggregation {
+    pub model: String,
+    pub usage: UsageAggregation,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SessionUsageAggregation {
+    pub usage: UsageAggregation,
+    pub models: Vec<ModelUsageAggregation>,
+    pub display_model: String,
+}
+
+fn has_usage(tokens: &TokenStats) -> bool {
+    tokens.total > 0
+        || tokens.input > 0
+        || tokens.output > 0
+        || tokens.cache_read.unwrap_or(0) > 0
+        || tokens.cache_write.unwrap_or(0) > 0
+        || tokens.reasoning.unwrap_or(0) > 0
+}
+
+fn add_tokens(aggregation: &mut UsageAggregation, tokens: &TokenStats) {
+    aggregation.total_tokens += tokens.total;
+    aggregation.input_tokens += tokens.input;
+    aggregation.output_tokens += tokens.output;
+    aggregation.cache_read_tokens += tokens.cache_read.unwrap_or(0);
+    aggregation.cache_write_tokens += tokens.cache_write.unwrap_or(0);
+    aggregation.reasoning_tokens += tokens.reasoning.unwrap_or(0);
+}
+
+fn entry_model(entry: &UsageEntry) -> Option<&str> {
+    entry
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+}
+
+fn record_usage(
+    result: &mut SessionUsageAggregation,
+    pricing_rules: &[PricingRule],
+    entry: &UsageEntry,
+    tokens: &TokenStats,
+) {
+    let model = entry_model(entry);
+    let model_label = model.unwrap_or("Unknown Model");
+    let cost_usd = match calculate_usage_cost(
+        pricing_rules,
+        model,
+        tokens.input,
+        tokens.output,
+        tokens.cache_read.unwrap_or(0),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => {
+            eprintln!("⚠️ 計算成本失敗: {}", error);
+            0.0
+        }
+    };
+
+    add_tokens(&mut result.usage, tokens);
+    result.usage.cost_usd += cost_usd;
+
+    let model_usage = if let Some(existing) = result
+        .models
+        .iter_mut()
+        .find(|item| item.model == model_label)
+    {
+        existing
+    } else {
+        result.models.push(ModelUsageAggregation {
+            model: model_label.to_string(),
+            usage: UsageAggregation::default(),
+        });
+        result.models.last_mut().unwrap()
+    };
+    add_tokens(&mut model_usage.usage, tokens);
+    model_usage.usage.cost_usd += cost_usd;
+}
+
+pub(crate) fn summarize_session_usage(
+    pricing_rules: &[PricingRule],
+    entries: &[UsageEntry],
+) -> SessionUsageAggregation {
+    let has_delta_usage = entries
+        .iter()
+        .filter_map(|entry| entry.delta_tokens.as_ref())
+        .any(has_usage);
+    let mut result = SessionUsageAggregation::default();
+    let mut display_entry: Option<&UsageEntry> = None;
+
+    if has_delta_usage {
+        for entry in entries {
+            let Some(tokens) = entry
+                .delta_tokens
+                .as_ref()
+                .filter(|tokens| has_usage(tokens))
+            else {
+                continue;
+            };
+            record_usage(&mut result, pricing_rules, entry, tokens);
+            if display_entry.is_none_or(|current| entry.turn_no >= current.turn_no) {
+                display_entry = Some(entry);
+            }
+        }
+    } else if let Some(entry) = entries
+        .iter()
+        .filter(|entry| entry.tokens.as_ref().is_some_and(has_usage))
+        .max_by_key(|entry| entry.turn_no)
+    {
+        record_usage(
+            &mut result,
+            pricing_rules,
+            entry,
+            entry.tokens.as_ref().unwrap(),
+        );
+        display_entry = Some(entry);
+    }
+
+    result.display_model = display_entry
+        .and_then(entry_model)
+        .unwrap_or("Unknown Model")
+        .to_string();
+    result
 }
 
 #[derive(Serialize)]
@@ -189,6 +330,7 @@ pub struct YearListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::db;
     use std::env;
     use std::fs;
@@ -199,6 +341,111 @@ mod tests {
 
     async fn lock_test_env() -> MutexGuard<'static, ()> {
         TEST_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await
+    }
+
+    fn token_stats(input: u64, output: u64, cache_read: u64) -> TokenStats {
+        TokenStats {
+            input,
+            output,
+            cache_read: Some(cache_read),
+            cache_write: Some(0),
+            reasoning: None,
+            total: input + output + cache_read,
+        }
+    }
+
+    fn usage_entry(turn_no: u32, model: &str, tokens: TokenStats, has_delta: bool) -> UsageEntry {
+        UsageEntry {
+            timestamp: format!("2026-07-10T10:{turn_no:02}:00Z"),
+            session_id: "mixed-model-session".to_string(),
+            session_name: None,
+            transcript_path: None,
+            cwd: None,
+            version: None,
+            turn_no,
+            model: Some(model.to_string()),
+            model_id: Some(model.to_string()),
+            tokens: Some(tokens.clone()),
+            delta_tokens: has_delta.then_some(tokens),
+            context: None,
+            cost: None,
+            source_kind: None,
+            parent_session_id: None,
+            agent_nickname: None,
+            agent_role: None,
+            reasoning_effort: None,
+        }
+    }
+
+    #[test]
+    fn session_cost_uses_each_delta_model_and_ignores_synthetic_tail() {
+        let rules = [
+            PricingRule {
+                model_name: "claude-opus-4-8".to_string(),
+                input_price: 10.0,
+                cache_input_price: 0.5,
+                output_price: 50.0,
+            },
+            PricingRule {
+                model_name: "claude-fable-5".to_string(),
+                input_price: 2.0,
+                cache_input_price: 0.2,
+                output_price: 4.0,
+            },
+        ];
+        let entries = vec![
+            usage_entry(
+                1,
+                "claude-opus-4-8",
+                token_stats(100_000, 10_000, 200_000),
+                true,
+            ),
+            usage_entry(
+                2,
+                "claude-fable-5",
+                token_stats(50_000, 5_000, 100_000),
+                true,
+            ),
+            usage_entry(3, "<synthetic>", token_stats(0, 0, 0), true),
+        ];
+
+        let result = summarize_session_usage(&rules, &entries);
+
+        assert!((result.usage.cost_usd - 1.74).abs() < 1e-9);
+        assert_eq!(result.usage.total_tokens, 465_000);
+        assert_eq!(result.display_model, "claude-fable-5");
+        assert_eq!(result.models.len(), 2);
+        assert!(result
+            .models
+            .iter()
+            .all(|usage| usage.model != "<synthetic>"));
+        assert!((result.models[0].usage.cost_usd - 1.6).abs() < 1e-9);
+        assert!((result.models[1].usage.cost_usd - 0.14).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cumulative_session_uses_last_entry_with_real_usage() {
+        let rules = [PricingRule {
+            model_name: "claude-opus-4-8".to_string(),
+            input_price: 10.0,
+            cache_input_price: 0.5,
+            output_price: 50.0,
+        }];
+        let entries = vec![
+            usage_entry(
+                1,
+                "claude-opus-4-8",
+                token_stats(100_000, 10_000, 200_000),
+                false,
+            ),
+            usage_entry(2, "<synthetic>", token_stats(0, 0, 0), false),
+        ];
+
+        let result = summarize_session_usage(&rules, &entries);
+
+        assert!((result.usage.cost_usd - 1.6).abs() < 1e-9);
+        assert_eq!(result.display_model, "claude-opus-4-8");
+        assert_eq!(result.models.len(), 1);
     }
 
     #[tokio::test]

--- a/src/handlers/monthly.rs
+++ b/src/handlers/monthly.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::*;
 use crate::db;
-use crate::pricing::{calculate_usage_cost, load_pricing_rules};
+use crate::pricing::load_pricing_rules;
 
 /// API 5: 獲取可用的有使用記錄月份
 pub async fn get_available_months(Path(assistant): Path<String>) -> impl IntoResponse {
@@ -129,96 +129,14 @@ pub async fn get_monthly_details(
                 .push(e.clone());
         }
 
-        for (sid, s_entries) in &day_sessions_map {
-            let s_tokens = s_entries
-                .iter()
-                .map(|e| e.delta_tokens.as_ref().map(|t| t.total).unwrap_or(0))
-                .sum::<u64>();
-            let s_input = s_entries
-                .iter()
-                .map(|e| e.delta_tokens.as_ref().map(|t| t.input).unwrap_or(0))
-                .sum::<u64>();
-            let s_output = s_entries
-                .iter()
-                .map(|e| e.delta_tokens.as_ref().map(|t| t.output).unwrap_or(0))
-                .sum::<u64>();
-            let s_cache = s_entries
-                .iter()
-                .map(|e| {
-                    e.delta_tokens
-                        .as_ref()
-                        .and_then(|t| t.cache_read)
-                        .unwrap_or(0)
-                })
-                .sum::<u64>();
-            let s_reasoning = s_entries
-                .iter()
-                .map(|e| {
-                    e.delta_tokens
-                        .as_ref()
-                        .and_then(|t| t.reasoning)
-                        .unwrap_or(0)
-                })
-                .sum::<u64>();
-
-            let last_entry = session_last_entries
-                .get(sid)
-                .cloned()
-                .unwrap_or_else(|| s_entries[0].clone());
-            let final_input = if s_tokens > 0 {
-                s_input
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.input).unwrap_or(0)
-            };
-            let final_output = if s_tokens > 0 {
-                s_output
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.output).unwrap_or(0)
-            };
-            let final_cache = if s_tokens > 0 {
-                s_cache
-            } else {
-                last_entry
-                    .tokens
-                    .as_ref()
-                    .and_then(|t| t.cache_read)
-                    .unwrap_or(0)
-            };
-            let final_reasoning = if s_tokens > 0 {
-                s_reasoning
-            } else {
-                last_entry
-                    .tokens
-                    .as_ref()
-                    .and_then(|t| t.reasoning)
-                    .unwrap_or(0)
-            };
-            let final_total = if s_tokens > 0 {
-                s_tokens
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.total).unwrap_or(0)
-            };
-
-            let cost_usd = match calculate_usage_cost(
-                &pricing_rules,
-                last_entry.model.as_deref(),
-                final_input,
-                final_output,
-                final_cache,
-            ) {
-                Ok(v) => v,
-                Err(err) => {
-                    eprintln!("⚠️ 計算成本失敗: {}", err);
-                    0.0
-                }
-            };
-
-            day_tokens += final_total;
-            day_input += final_input;
-            day_output += final_output;
-            day_cache_read += final_cache;
-            day_reasoning += final_reasoning;
-            day_cost_usd += cost_usd;
+        for s_entries in day_sessions_map.values() {
+            let session_usage = summarize_session_usage(&pricing_rules, s_entries);
+            day_tokens += session_usage.usage.total_tokens;
+            day_input += session_usage.usage.input_tokens;
+            day_output += session_usage.usage.output_tokens;
+            day_cache_read += session_usage.usage.cache_read_tokens;
+            day_reasoning += session_usage.usage.reasoning_tokens;
+            day_cost_usd += session_usage.usage.cost_usd;
         }
 
         monthly_summary.total_tokens += day_tokens;
@@ -252,110 +170,33 @@ pub async fn get_monthly_details(
             .get(session_id)
             .cloned()
             .unwrap_or_else(|| s_entries[0].clone());
-
-        let s_tokens = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.total).unwrap_or(0))
-            .sum::<u64>();
-        let s_input = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.input).unwrap_or(0))
-            .sum::<u64>();
-        let s_output = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.output).unwrap_or(0))
-            .sum::<u64>();
-        let s_cache = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.cache_read)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
-        let s_reasoning = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.reasoning)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
-
-        let final_input = if s_tokens > 0 {
-            s_input
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.input).unwrap_or(0)
-        };
-        let final_output = if s_tokens > 0 {
-            s_output
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.output).unwrap_or(0)
-        };
-        let final_cache = if s_tokens > 0 {
-            s_cache
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.cache_read)
-                .unwrap_or(0)
-        };
-        let final_reasoning = if s_tokens > 0 {
-            s_reasoning
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.reasoning)
-                .unwrap_or(0)
-        };
-        let final_total = if s_tokens > 0 {
-            s_tokens
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.total).unwrap_or(0)
-        };
-
-        let cost_usd = match calculate_usage_cost(
-            &pricing_rules,
-            last_entry.model.as_deref(),
-            final_input,
-            final_output,
-            final_cache,
-        ) {
-            Ok(v) => v,
-            Err(err) => {
-                eprintln!("⚠️ 計算成本失敗: {}", err);
-                0.0
-            }
-        };
+        let session_usage = summarize_session_usage(&pricing_rules, s_entries);
 
         let cwd = last_entry.cwd.unwrap_or_else(|| "Unknown CWD".to_string());
         let project_stat = project_map_stats.entry(cwd).or_insert((0, 0, 0.0));
         project_stat.0 += 1;
-        project_stat.1 += final_total;
-        project_stat.2 += cost_usd;
+        project_stat.1 += session_usage.usage.total_tokens;
+        project_stat.2 += session_usage.usage.cost_usd;
 
-        let model = last_entry
-            .model
-            .unwrap_or_else(|| "Unknown Model".to_string());
-        let model_stat = model_map_stats.entry(model).or_insert((0, 0, 0, 0, 0, 0.0));
-        model_stat.0 += 1;
-        model_stat.1 += final_total;
-        model_stat.2 += final_input;
-        model_stat.3 += final_output;
-        model_stat.4 += final_cache;
-        model_stat.5 += cost_usd;
+        for model_usage in &session_usage.models {
+            let model_stat = model_map_stats
+                .entry(model_usage.model.clone())
+                .or_insert((0, 0, 0, 0, 0, 0.0));
+            model_stat.0 += 1;
+            model_stat.1 += model_usage.usage.total_tokens;
+            model_stat.2 += model_usage.usage.input_tokens;
+            model_stat.3 += model_usage.usage.output_tokens;
+            model_stat.4 += model_usage.usage.cache_read_tokens;
+            model_stat.5 += model_usage.usage.cost_usd;
+        }
 
         let agent_stat = agent_map_stats.entry(ast_type.clone()).or_default();
-        agent_stat.total_tokens += final_total;
-        agent_stat.total_input_tokens += final_input;
-        agent_stat.total_output_tokens += final_output;
-        agent_stat.total_cache_read_tokens += final_cache;
-        agent_stat.total_reasoning_tokens += final_reasoning;
-        agent_stat.total_cost_usd += cost_usd;
+        agent_stat.total_tokens += session_usage.usage.total_tokens;
+        agent_stat.total_input_tokens += session_usage.usage.input_tokens;
+        agent_stat.total_output_tokens += session_usage.usage.output_tokens;
+        agent_stat.total_cache_read_tokens += session_usage.usage.cache_read_tokens;
+        agent_stat.total_reasoning_tokens += session_usage.usage.reasoning_tokens;
+        agent_stat.total_cost_usd += session_usage.usage.cost_usd;
         agent_stat.total_sessions += 1;
     }
 

--- a/src/handlers/yearly.rs
+++ b/src/handlers/yearly.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::*;
 use crate::db;
-use crate::pricing::{calculate_usage_cost, load_pricing_rules};
+use crate::pricing::load_pricing_rules;
 
 /// API 12: 獲取可用的有使用記錄年份
 pub async fn get_available_years(Path(assistant): Path<String>) -> impl IntoResponse {
@@ -134,96 +134,14 @@ pub async fn get_yearly_details(
                 .push(e.clone());
         }
 
-        for (sid, s_entries) in &month_sessions_map {
-            let s_tokens = s_entries
-                .iter()
-                .map(|e| e.delta_tokens.as_ref().map(|t| t.total).unwrap_or(0))
-                .sum::<u64>();
-            let s_input = s_entries
-                .iter()
-                .map(|e| e.delta_tokens.as_ref().map(|t| t.input).unwrap_or(0))
-                .sum::<u64>();
-            let s_output = s_entries
-                .iter()
-                .map(|e| e.delta_tokens.as_ref().map(|t| t.output).unwrap_or(0))
-                .sum::<u64>();
-            let s_cache = s_entries
-                .iter()
-                .map(|e| {
-                    e.delta_tokens
-                        .as_ref()
-                        .and_then(|t| t.cache_read)
-                        .unwrap_or(0)
-                })
-                .sum::<u64>();
-            let s_reasoning = s_entries
-                .iter()
-                .map(|e| {
-                    e.delta_tokens
-                        .as_ref()
-                        .and_then(|t| t.reasoning)
-                        .unwrap_or(0)
-                })
-                .sum::<u64>();
-
-            let last_entry = session_last_entries
-                .get(sid)
-                .cloned()
-                .unwrap_or_else(|| s_entries[0].clone());
-            let final_input = if s_tokens > 0 {
-                s_input
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.input).unwrap_or(0)
-            };
-            let final_output = if s_tokens > 0 {
-                s_output
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.output).unwrap_or(0)
-            };
-            let final_cache = if s_tokens > 0 {
-                s_cache
-            } else {
-                last_entry
-                    .tokens
-                    .as_ref()
-                    .and_then(|t| t.cache_read)
-                    .unwrap_or(0)
-            };
-            let final_reasoning = if s_tokens > 0 {
-                s_reasoning
-            } else {
-                last_entry
-                    .tokens
-                    .as_ref()
-                    .and_then(|t| t.reasoning)
-                    .unwrap_or(0)
-            };
-            let final_total = if s_tokens > 0 {
-                s_tokens
-            } else {
-                last_entry.tokens.as_ref().map(|t| t.total).unwrap_or(0)
-            };
-
-            let cost_usd = match calculate_usage_cost(
-                &pricing_rules,
-                last_entry.model.as_deref(),
-                final_input,
-                final_output,
-                final_cache,
-            ) {
-                Ok(v) => v,
-                Err(err) => {
-                    eprintln!("⚠️ 計算成本失敗: {}", err);
-                    0.0
-                }
-            };
-
-            m_tokens += final_total;
-            m_input += final_input;
-            m_output += final_output;
-            m_cache_read += final_cache;
-            m_reasoning += final_reasoning;
-            m_cost_usd += cost_usd;
+        for s_entries in month_sessions_map.values() {
+            let session_usage = summarize_session_usage(&pricing_rules, s_entries);
+            m_tokens += session_usage.usage.total_tokens;
+            m_input += session_usage.usage.input_tokens;
+            m_output += session_usage.usage.output_tokens;
+            m_cache_read += session_usage.usage.cache_read_tokens;
+            m_reasoning += session_usage.usage.reasoning_tokens;
+            m_cost_usd += session_usage.usage.cost_usd;
         }
 
         yearly_summary.total_tokens += m_tokens;
@@ -257,110 +175,33 @@ pub async fn get_yearly_details(
             .get(session_id)
             .cloned()
             .unwrap_or_else(|| s_entries[0].clone());
-
-        let s_tokens = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.total).unwrap_or(0))
-            .sum::<u64>();
-        let s_input = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.input).unwrap_or(0))
-            .sum::<u64>();
-        let s_output = s_entries
-            .iter()
-            .map(|e| e.delta_tokens.as_ref().map(|t| t.output).unwrap_or(0))
-            .sum::<u64>();
-        let s_cache = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.cache_read)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
-        let s_reasoning = s_entries
-            .iter()
-            .map(|e| {
-                e.delta_tokens
-                    .as_ref()
-                    .and_then(|t| t.reasoning)
-                    .unwrap_or(0)
-            })
-            .sum::<u64>();
-
-        let final_input = if s_tokens > 0 {
-            s_input
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.input).unwrap_or(0)
-        };
-        let final_output = if s_tokens > 0 {
-            s_output
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.output).unwrap_or(0)
-        };
-        let final_cache = if s_tokens > 0 {
-            s_cache
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.cache_read)
-                .unwrap_or(0)
-        };
-        let final_reasoning = if s_tokens > 0 {
-            s_reasoning
-        } else {
-            last_entry
-                .tokens
-                .as_ref()
-                .and_then(|t| t.reasoning)
-                .unwrap_or(0)
-        };
-        let final_total = if s_tokens > 0 {
-            s_tokens
-        } else {
-            last_entry.tokens.as_ref().map(|t| t.total).unwrap_or(0)
-        };
-
-        let cost_usd = match calculate_usage_cost(
-            &pricing_rules,
-            last_entry.model.as_deref(),
-            final_input,
-            final_output,
-            final_cache,
-        ) {
-            Ok(v) => v,
-            Err(err) => {
-                eprintln!("⚠️ 計算成本失敗: {}", err);
-                0.0
-            }
-        };
+        let session_usage = summarize_session_usage(&pricing_rules, s_entries);
 
         let cwd = last_entry.cwd.unwrap_or_else(|| "Unknown CWD".to_string());
         let project_stat = project_map_stats.entry(cwd).or_insert((0, 0, 0.0));
         project_stat.0 += 1;
-        project_stat.1 += final_total;
-        project_stat.2 += cost_usd;
+        project_stat.1 += session_usage.usage.total_tokens;
+        project_stat.2 += session_usage.usage.cost_usd;
 
-        let model = last_entry
-            .model
-            .unwrap_or_else(|| "Unknown Model".to_string());
-        let model_stat = model_map_stats.entry(model).or_insert((0, 0, 0, 0, 0, 0.0));
-        model_stat.0 += 1;
-        model_stat.1 += final_total;
-        model_stat.2 += final_input;
-        model_stat.3 += final_output;
-        model_stat.4 += final_cache;
-        model_stat.5 += cost_usd;
+        for model_usage in &session_usage.models {
+            let model_stat = model_map_stats
+                .entry(model_usage.model.clone())
+                .or_insert((0, 0, 0, 0, 0, 0.0));
+            model_stat.0 += 1;
+            model_stat.1 += model_usage.usage.total_tokens;
+            model_stat.2 += model_usage.usage.input_tokens;
+            model_stat.3 += model_usage.usage.output_tokens;
+            model_stat.4 += model_usage.usage.cache_read_tokens;
+            model_stat.5 += model_usage.usage.cost_usd;
+        }
 
         let agent_stat = agent_map_stats.entry(ast_type.clone()).or_default();
-        agent_stat.total_tokens += final_total;
-        agent_stat.total_input_tokens += final_input;
-        agent_stat.total_output_tokens += final_output;
-        agent_stat.total_cache_read_tokens += final_cache;
-        agent_stat.total_reasoning_tokens += final_reasoning;
-        agent_stat.total_cost_usd += cost_usd;
+        agent_stat.total_tokens += session_usage.usage.total_tokens;
+        agent_stat.total_input_tokens += session_usage.usage.input_tokens;
+        agent_stat.total_output_tokens += session_usage.usage.output_tokens;
+        agent_stat.total_cache_read_tokens += session_usage.usage.cache_read_tokens;
+        agent_stat.total_reasoning_tokens += session_usage.usage.reasoning_tokens;
+        agent_stat.total_cost_usd += session_usage.usage.cost_usd;
         agent_stat.total_sessions += 1;
     }
 


### PR DESCRIPTION
## 變更內容

- 新增共用 Session 使用量彙整器，依每筆 `delta_tokens` 與該筆實際模型分別計價。
- 零 Token 的 `<synthetic>` 收尾不再使整個 Session 成本歸零。
- 沒有 delta 的舊格式改取最後一筆具有實際使用量的累計資料，不取零 Token 收尾。
- 日、月、年 API 共用同一套成本邏輯。
- 月／年模型統計依實際產生 Token 的模型拆分，跨模型 Session 不再全部歸到最後一個模型。
- 日檢視的 Session 模型顯示最後一個有實際 Token 的模型。

## 根本原因

原本三個統計端點先加總整個 Session 的 Token，再用 `last_entry.model` 套用單一費率。跨模型 Session 會套錯費率；若最後一筆是 `<synthetic>`，價格規則查找失敗後整段成本直接記為 0。

## 驗證

- 新增跨模型加 synthetic 收尾回歸測試，確認逐筆成本為 1.74 美元且模型分組正確。
- 新增無 delta 累計格式測試，確認略過零 Token synthetic 收尾。
- `cargo test`：主程式 53 項、CLI 38 項測試通過。
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release --all-targets`
- 使用隔離 SQLite 與合成資料實際呼叫日、月、年 API：三者成本均為 0.9775 美元；月／年分別列出 Opus 0.3675 與 Fable 0.61，未列入 `<synthetic>`。

Fixes #3