### PR TITLE
feat(pricing): add claude-opus-5 pricing rule

### DIFF
--- a/pricing.csv
+++ b/pricing.csv
@@ -34,6 +34,7 @@ Claude Sonnet 4.6,Global,1M Tokens,3.00,0.30,15.00,N/A
 Claude Sonnet 4.5,Global,1M Tokens,3.00,0.30,15.00,N/A
 Claude Haiku 4.5,Global,1M Tokens,1.00,0.10,5.00,N/A
 Claude Fable 5,Global,1M Tokens,10.00,1.00,50.00,N/A
+Claude Opus 5,Global,1M Tokens,5.00,0.50,25.00,N/A
 Claude Opus 4.8-fast,Global,1M Tokens,10.00,1.00,50.00,N/A
 Claude Opus 4.8,Global,1M Tokens,5.00,0.50,25.00,N/A
 Claude Opus 4.7,Global,1M Tokens,5.00,0.50,25.00,N/A
@@ -113,6 +114,7 @@ claude-4-sonnet,Cursor,1M Tokens,3.00,0.30,15.00,N/A
 claude-4-sonnet-1m,Cursor,1M Tokens,3.00,0.30,15.00,N/A
 claude-4-5-haiku,Cursor,1M Tokens,1.00,0.10,5.00,N/A
 claude-fable-5,Cursor,1M Tokens,10.00,1.00,50.00,N/A
+claude-opus-5,Cursor,1M Tokens,5.00,0.50,25.00,N/A
 claude-opus-4-8,Cursor,1M Tokens,5.00,0.50,25.00,N/A
 claude-opus-4-7-fast,Cursor,1M Tokens,10.00,1.00,50.00,N/A
 claude-opus-4-7,Cursor,1M Tokens,5.00,0.50,25.00,N/A


### PR DESCRIPTION
### 摘要
這個 PR 根據 Anthropic 最新發布的官方計價表，補上了遺漏的 `claude-opus-5` 模型計價規則。

### 修改內容
- 在 `pricing.csv` 中新增了 `claude-opus-5` (Cursor) 與 `Claude Opus 5` (Global) 的項目。
- 已將價格設定與 Claude 5 Opus 的官方價格同步：
  - **輸入 (Input)**：$5.00 / 1M Tokens
  - **輸出 (Output)**：$25.00 / 1M Tokens
  - **快取讀取 (Cache Read)**：$0.50 / 1M Tokens

### 相關證明
<img width="1463" height="409" alt="image" src="https://github.com/user-attachments/assets/59e6021c-7927-4be7-97bf-2dd45fd88a11" />
