### PR TITLE
feat: support launchd service installation on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,14 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 
 這會下載安裝版並立即啟用 `token-usage-insights.service`，不需要自行建置或修改 systemd 檔案。
 
+### macOS：一行安裝並啟用 launchd LaunchAgent
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
+```
+
+這會將 `com.tokenusageinsights.plist` 安裝到 `~/Library/LaunchAgents/` 並立即載入；標準輸出與錯誤日誌位於 `~/Library/Logs/`。
+
 ### 管理服務
 
 ```bash
@@ -471,6 +479,14 @@ systemctl --user status token-usage-insights.service
 journalctl --user -u token-usage-insights.service -n 50 -f
 systemctl --user restart token-usage-insights.service
 systemctl --user stop token-usage-insights.service
+```
+
+macOS 可使用：
+
+```bash
+launchctl print gui/$(id -u)/com.tokenusageinsights
+launchctl kickstart -k gui/$(id -u)/com.tokenusageinsights
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.plist
 ```
 
 * * *
@@ -489,7 +505,7 @@ Linux / macOS：
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash
 ```
 
-Linux 如需同時安裝並啟用 systemd user service：
+Linux（systemd user service）或 macOS（launchd LaunchAgent）如需同時安裝並啟用常駐服務：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
@@ -541,7 +557,7 @@ cd token-usage-insights-<tag>-<target>
 ./install.sh
 ```
 
-Linux 如需安裝並啟用 systemd user service：
+Linux（systemd user service）或 macOS（launchd LaunchAgent）如需安裝並啟用常駐服務：
 
 ```bash
 ./install.sh --service

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,7 +22,8 @@ Environment:
   PORT                              Dashboard port. Default: 3003
 
 Options:
-  --service                         Install and enable a systemd user service on Linux.
+  --service                         Install and enable a background user service
+                                    (systemd on Linux; launchd on macOS).
 USAGE
 }
 
@@ -78,19 +79,17 @@ done
 ln -sfn "${install_dir}/${app_name}" "${bin_dir}/${app_name}"
 
 if [[ "$install_service" == true ]]; then
-  if [[ "$(uname -s)" != "Linux" ]]; then
-    echo "--service is only supported on Linux with systemd." >&2
-    exit 1
-  fi
-  if ! command -v systemctl >/dev/null 2>&1; then
-    echo "systemctl was not found; cannot install the user service." >&2
-    exit 1
-  fi
+  case "$(uname -s)" in
+    Linux)
+      if ! command -v systemctl >/dev/null 2>&1; then
+        echo "systemctl was not found; cannot install the user service." >&2
+        exit 1
+      fi
 
-  service_dir="${HOME}/.config/systemd/user"
-  service_file="${service_dir}/${app_name}.service"
-  mkdir -p "$service_dir"
-  cat > "$service_file" <<SERVICE
+      service_dir="${HOME}/.config/systemd/user"
+      service_file="${service_dir}/${app_name}.service"
+      mkdir -p "$service_dir"
+      cat > "$service_file" <<SERVICE
 [Unit]
 Description=Token 戰情室 Dashboard Service
 After=network.target
@@ -108,8 +107,85 @@ Environment=HOST=${host}
 WantedBy=default.target
 SERVICE
 
-  systemctl --user daemon-reload
-  systemctl --user enable --now "${app_name}.service"
+      systemctl --user daemon-reload
+      systemctl --user enable --now "${app_name}.service"
+      ;;
+    Darwin)
+      if ! command -v launchctl >/dev/null 2>&1; then
+        echo "launchctl was not found; cannot install the launchd agent." >&2
+        exit 1
+      fi
+      if ! command -v plutil >/dev/null 2>&1; then
+        echo "plutil was not found; cannot validate the launchd agent plist." >&2
+        exit 1
+      fi
+
+      launch_agents_dir="${HOME}/Library/LaunchAgents"
+      launch_logs_dir="${HOME}/Library/Logs"
+      launch_label="com.tokenusageinsights"
+      launch_agent_file="${launch_agents_dir}/${launch_label}.plist"
+      launch_domain="gui/$(id -u)"
+      mkdir -p "$launch_agents_dir" "$launch_logs_dir"
+
+      plist_escape() {
+        printf '%s' "$1" | sed \
+          -e 's/&/\&amp;/g' \
+          -e 's/</\&lt;/g' \
+          -e 's/>/\&gt;/g' \
+          -e 's/"/\&quot;/g' \
+          -e "s/'/\&apos;/g"
+      }
+
+      executable_plist="$(plist_escape "${install_dir}/${app_name}")"
+      install_dir_plist="$(plist_escape "$install_dir")"
+      host_plist="$(plist_escape "$host")"
+      port_plist="$(plist_escape "$port")"
+      stdout_log_plist="$(plist_escape "${launch_logs_dir}/${launch_label}.out.log")"
+      stderr_log_plist="$(plist_escape "${launch_logs_dir}/${launch_label}.err.log")"
+
+      cat > "$launch_agent_file" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${launch_label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${executable_plist}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${install_dir_plist}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOST</key>
+    <string>${host_plist}</string>
+    <key>PORT</key>
+    <string>${port_plist}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${stdout_log_plist}</string>
+  <key>StandardErrorPath</key>
+  <string>${stderr_log_plist}</string>
+</dict>
+</plist>
+PLIST
+
+      plutil -lint "$launch_agent_file"
+
+      # A previous instance may be loaded; bootout is intentionally harmless if it is not.
+      launchctl bootout "${launch_domain}/${launch_label}" >/dev/null 2>&1 || true
+      launchctl bootstrap "$launch_domain" "$launch_agent_file"
+      ;;
+    *)
+      echo "--service is unsupported on $(uname -s). Supported platforms: Linux (systemd) and macOS (launchd)." >&2
+      exit 1
+      ;;
+  esac
 fi
 
 cat <<DONE


### PR DESCRIPTION
## Summary

Add macOS launchd support to the existing `--service` installer option.

- Keep the existing Linux systemd user service behavior
- Add a macOS LaunchAgent using `launchd`
- Install the LaunchAgent under `~/Library/LaunchAgents`
- Preserve `HOST` and `PORT` environment configuration
- Start the service automatically when the user logs in
- Support safe reinstallation by replacing an existing loaded LaunchAgent
- Validate the generated plist with `plutil` before loading it

## Testing

Tested on macOS:

- `bash -n scripts/install.sh`
- `git diff --check`
- LaunchAgent plist validation with `plutil`
- `launchctl bootstrap`
- `launchctl print`
- HTTP access to the dashboard
- Service restart
- Re-running `--service` to verify reinstallation behavior

The existing Linux systemd behavior is preserved.