### PR TITLE
fix(vscode): 從 Copilot Chat 除錯記錄補回 VS Code Session 的快取讀取 Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## [未發行]
 
+### 修正
+
+- 修復 GitHub Copilot Chat（VS Code）Session 的「快取讀取 Token」永遠顯示 0 的問題（[#41](https://github.com/doggy8088/TokenUsageInsights/issues/41)）。VS Code 的 `chatSessions` 檔案本身不記錄快取讀取數；看板現在會一併讀取 Copilot Chat 擴充功能寫入的 `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`，依 `user_message` 回合加總 `inputTokens`、`outputTokens` 與 `cachedTokens`，並以提示文字與時間戳配對到對應的聊天請求。
+- VS Code Copilot Chat 的同步狀態現在會納入除錯記錄檔的大小與修改時間，確保擴充功能在聊天檔案寫入後數秒才刷寫的除錯記錄能在下一次同步被補上。
+
+### 變更
+
+- 有除錯記錄的 VS Code Copilot Chat 回合，輸入 Token 改為該回合所有模型呼叫的非快取輸入總和（原本只採用最後一次呼叫的 `promptTokens`），輸出 Token 為各呼叫輸出的總和，成本估算因此能依快取讀取費率計價；沒有除錯記錄的回合維持原有行為。
+
+### 相容性
+
+- 無資料庫結構、環境變數或安裝流程變更。既有 VS Code Copilot Chat Session 會在下一次同步時依除錯記錄重新計算 Token。
+
 ## [0.9.3] - 2026-09-10
 
 ### 修正

--- a/README.en.md
+++ b/README.en.md
@@ -277,6 +277,8 @@ Usage:
 
 The dashboard fully backfills existing `chatSessions` files and resynchronizes them when file size or modification time changes. Chat sessions without token fields are still shown with a token count of 0. Only local chat files are read; cloud sessions, Remote SSH hosts, and `state.vscdb` are not included.
 
+**Where cache-read tokens come from**: VS Code's `chatSessions` files only persist the `promptTokens` of the last model call in a request plus the accumulated `completionTokens`; they never record prompt-cache reads. The dashboard therefore also reads the Copilot Chat extension debug log written next to them, `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`, sums `inputTokens`, `outputTokens`, and `cachedTokens` across every model call of the turn, and splits the result into non-cached input, cache read, and output tokens so cost estimates use the cache-read rate. The debug log is controlled by the VS Code setting `github.copilot.chat.agentDebugLog.fileLogging.enabled` (already enabled by experiment for some users) and keeps only the 50 most recent sessions by default. Sessions without a debug log fall back to VS Code's own token fields and show 0 cache reads.
+
 If VS Code uses `--user-data-dir` or Portable Mode, specify a custom data root for the dashboard:
 
 macOS / Linux:

--- a/README.ja.md
+++ b/README.ja.md
@@ -277,6 +277,8 @@ VS Code Stable と Insiders に対応しています：
 
 既存の `chatSessions` ファイルは完全に取り込み、ファイルサイズまたは更新日時が変わると再同期します。Token フィールドのないチャット Session も表示されますが、Token 数は 0 です。読み取るのはローカルのチャットファイルだけで、クラウド Session、Remote SSH ホスト、`state.vscdb` は含まれません。
 
+**キャッシュ読み取り Token の取得元**：VS Code の `chatSessions` ファイルには、各リクエストの最後のモデル呼び出しの `promptTokens` と累計の `completionTokens` しか記録されず、Prompt Cache のキャッシュ読み取り数は記録されません。そのためダッシュボードは、同じワークスペースディレクトリに Copilot Chat 拡張機能が書き出すデバッグログ `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl` も読み取り、そのターンの全モデル呼び出しの `inputTokens`・`outputTokens`・`cachedTokens` を合計して、非キャッシュ入力・キャッシュ読み取り・出力 Token に分解し、コスト推定にもキャッシュ読み取り単価を適用します。このデバッグログは VS Code 設定 `github.copilot.chat.agentDebugLog.fileLogging.enabled` で制御され（一部ユーザーには実験機能として有効化済み）、既定では最新 50 Session 分のみ保持されます。デバッグログのない Session は VS Code 標準の Token フィールドにフォールバックし、キャッシュ読み取りは 0 と表示されます。
+
 VS Code で `--user-data-dir` または Portable Mode を使う場合は、ダッシュボードのカスタムデータルートを指定できます：
 
 macOS / Linux：

--- a/README.ko.md
+++ b/README.ko.md
@@ -277,6 +277,8 @@ VS Code Stable 및 Insiders를 지원합니다.
 
 대시보드는 기존 `chatSessions` 파일을 모두 채우고 파일 크기나 수정 시간이 변경되면 다시 동기화합니다. Token 필드가 없는 채팅 Session도 표시되지만 Token 수는 0입니다. 로컬 채팅 파일만 읽으며 클라우드 Session, Remote SSH 호스트 또는 `state.vscdb`는 포함하지 않습니다.
 
+**캐시 읽기 Token 출처**: VS Code의 `chatSessions` 파일은 각 요청에서 마지막 모델 호출의 `promptTokens`와 누적 `completionTokens`만 기록하며 Prompt Cache 캐시 읽기 수는 기록하지 않습니다. 따라서 대시보드는 같은 워크스페이스 디렉터리에 Copilot Chat 확장이 기록하는 디버그 로그 `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`도 함께 읽어, 해당 턴의 모든 모델 호출의 `inputTokens`, `outputTokens`, `cachedTokens`를 합산한 뒤 비캐시 입력, 캐시 읽기, 출력 Token으로 나누고 비용 추정에도 캐시 읽기 단가를 적용합니다. 이 디버그 로그는 VS Code 설정 `github.copilot.chat.agentDebugLog.fileLogging.enabled`로 제어되며(일부 사용자는 실험 기능으로 이미 활성화됨) 기본적으로 최근 50개 Session만 보존합니다. 디버그 로그가 없는 Session은 VS Code 기본 Token 필드로 대체되며 캐시 읽기는 0으로 표시됩니다.
+
 VS Code에서 `--user-data-dir` 또는 Portable Mode를 사용하는 경우 대시보드의 사용자 지정 데이터 루트를 지정할 수 있습니다.
 
 macOS / Linux:

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ COPILOT_APP_DIR="/path/to/copilot-app-data" token-usage-insights
 
 看板會完整回填現有 `chatSessions` 檔案，也會在檔案大小或修改時間變更時重新同步；沒有 Token 欄位的聊天 Session 仍會顯示，但 Token 數為 0。資料只讀取本機聊天檔案，不包含雲端 Session、Remote SSH 主機或 `state.vscdb`。
 
+**快取讀取 Token 來源**：VS Code 的 `chatSessions` 檔案只記錄每個請求最後一次模型呼叫的 `promptTokens` 與累計的 `completionTokens`，並不記錄 Prompt Cache 的快取讀取數。看板會另外讀取 Copilot Chat 擴充功能在同一個工作區目錄下寫入的除錯記錄 `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`，把該回合所有模型呼叫的 `inputTokens`、`outputTokens` 與 `cachedTokens` 加總後，拆成非快取輸入、快取讀取與輸出 Token，成本估算也會依快取讀取費率計價。此除錯記錄由 VS Code 設定 `github.copilot.chat.agentDebugLog.fileLogging.enabled` 控制（部分使用者已由實驗功能開啟），且預設只保留最近 50 個 Session 的記錄；沒有除錯記錄的 Session 會回退使用 VS Code 內建的 Token 欄位，快取讀取會顯示為 0。
+
 若 VS Code 使用 `--user-data-dir` 或 Portable Mode，可指定看板自訂的資料根目錄：
 
 macOS / Linux：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -277,6 +277,8 @@ COPILOT_APP_DIR="/path/to/copilot-app-data" token-usage-insights
 
 看板会完整回填现有的 `chatSessions` 文件，并在文件大小或修改时间变化时重新同步；没有 Token 字段的聊天 Session 仍会显示，但 Token 数为 0。数据只读取本地聊天文件，不包含云端 Session、Remote SSH 主机或 `state.vscdb`。
 
+**缓存读取 Token 来源**：VS Code 的 `chatSessions` 文件只记录每个请求最后一次模型调用的 `promptTokens` 与累计的 `completionTokens`，并不记录 Prompt Cache 的缓存读取数。看板会另外读取 Copilot Chat 扩展在同一个工作区目录下写入的调试日志 `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`，把该回合所有模型调用的 `inputTokens`、`outputTokens` 与 `cachedTokens` 加总后，拆成非缓存输入、缓存读取与输出 Token，成本估算也会按缓存读取费率计价。此调试日志由 VS Code 设置 `github.copilot.chat.agentDebugLog.fileLogging.enabled` 控制（部分用户已由实验功能开启），且默认只保留最近 50 个 Session 的记录；没有调试日志的 Session 会回退使用 VS Code 内置的 Token 字段，缓存读取会显示为 0。
+
 如果 VS Code 使用 `--user-data-dir` 或 Portable Mode，可以指定看板自定义的数据根目录：
 
 macOS / Linux：

--- a/src/db.rs
+++ b/src/db.rs
@@ -1549,6 +1549,34 @@ fn insert_vscode_usage_entry(
     )
 }
 
+fn file_modified_nanos(metadata: &fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|value| value.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+/// Sync-state signature `(size, mtime)` of a VS Code chat session file.
+///
+/// The Copilot Chat extension flushes its per-session debug log (the only
+/// local source of prompt-cache reads) a few seconds after VS Code finishes
+/// writing the `chatSessions` file. Folding the debug log's size and mtime into
+/// the signature makes a later flush trigger a resync instead of leaving the
+/// session stuck without cache-read tokens.
+fn vscode_sync_signature(filepath: &Path, metadata: &fs::Metadata) -> (u64, i64) {
+    let mut size = metadata.len();
+    let mut modified = file_modified_nanos(metadata);
+    if let Some(debug_metadata) =
+        crate::vscode::debug_log_path(filepath).and_then(|debug_path| fs::metadata(debug_path).ok())
+    {
+        size = size.saturating_add(debug_metadata.len());
+        modified = modified.max(file_modified_nanos(&debug_metadata));
+    }
+    (size, modified)
+}
+
 fn sync_vscode_chat_sessions(conn: &mut Connection) -> Result<(), String> {
     let mut seen_sessions = HashSet::new();
 
@@ -1557,13 +1585,7 @@ fn sync_vscode_chat_sessions(conn: &mut Connection) -> Result<(), String> {
             Ok(metadata) => metadata,
             Err(_) => continue,
         };
-        let current_size = metadata.len();
-        let modified_time = metadata
-            .modified()
-            .ok()
-            .and_then(|value| value.duration_since(SystemTime::UNIX_EPOCH).ok())
-            .map(|value| value.as_nanos() as i64)
-            .unwrap_or(0);
+        let (current_size, modified_time) = vscode_sync_signature(&filepath, &metadata);
         let state_key = format!("vscode:{}", filepath.to_string_lossy());
         let previous_state: Option<(u64, i64)> = conn
             .query_row(
@@ -7703,6 +7725,7 @@ pub fn get_usage_entries_by_year(
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Mutex,
@@ -7710,6 +7733,49 @@ mod tests {
 
     static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn vscode_sync_signature_includes_debug_log_size_and_mtime() {
+        let root = std::env::temp_dir().join(format!(
+            "tui-vscode-sync-signature-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let workspace = root.join("workspaceStorage").join("ws1");
+        let chat_sessions = workspace.join("chatSessions");
+        fs::create_dir_all(&chat_sessions).unwrap();
+        let session_file = chat_sessions.join("abc.jsonl");
+        fs::write(&session_file, "0123456789").unwrap();
+        let metadata = fs::metadata(&session_file).unwrap();
+
+        // Without a debug log the signature is just the session file itself.
+        let (size, modified) = vscode_sync_signature(&session_file, &metadata);
+        assert_eq!(size, 10);
+        assert_eq!(modified, file_modified_nanos(&metadata));
+
+        // A debug log flushed later grows the size and bumps the mtime, so the
+        // session is picked up by the next sync even though the chat file is
+        // unchanged.
+        let debug_path = crate::vscode::debug_log_path(&session_file).unwrap();
+        fs::create_dir_all(debug_path.parent().unwrap()).unwrap();
+        fs::write(&debug_path, "{}\n{}\n").unwrap();
+        let future = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(4_102_444_800);
+        fs::File::options()
+            .write(true)
+            .open(&debug_path)
+            .unwrap()
+            .set_modified(future)
+            .unwrap();
+        let (size_with_log, modified_with_log) = vscode_sync_signature(&session_file, &metadata);
+        assert_eq!(size_with_log, 10 + 6);
+        assert!(modified_with_log > modified);
+        assert_eq!(
+            modified_with_log,
+            file_modified_nanos(&fs::metadata(&debug_path).unwrap())
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
 
     fn temp_jsonl_path(prefix: &str) -> PathBuf {
         let mut path = std::env::temp_dir();

--- a/src/vscode.rs
+++ b/src/vscode.rs
@@ -3,12 +3,29 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use std::borrow::Cow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 pub const SOURCE_KIND: &str = "vscode-chat";
 const SESSION_ID_PREFIX: &str = "vscode-";
+
+/// Copilot Chat extension workspace storage folder that sits next to
+/// `chatSessions/` inside each `workspaceStorage/<workspace>/` directory.
+const COPILOT_CHAT_STORAGE_DIR: &str = "GitHub.copilot-chat";
+/// Per-session debug log folder written by the Copilot Chat extension when
+/// `github.copilot.chat.agentDebugLog.fileLogging.enabled` is on (the setting
+/// is also enabled by experiment for many users). Layout:
+/// `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`.
+const COPILOT_CHAT_DEBUG_LOGS_DIR: &str = "debug-logs";
+const COPILOT_CHAT_DEBUG_LOG_FILE: &str = "main.jsonl";
+/// The debug logger truncates long prompts and appends this marker.
+const COPILOT_CHAT_DEBUG_LOG_TRUNCATED_SUFFIX: &str = "[truncated]";
+/// A `user_message` span is emitted a second or two after VS Code stamps the
+/// chat request. Accept a timestamp-only match within this window.
+const COPILOT_CHAT_DEBUG_LOG_TIMESTAMP_TOLERANCE_MS: i64 = 120_000;
+/// Upper bound when walking `parentSpanId` links back to a `user_message`.
+const COPILOT_CHAT_DEBUG_LOG_MAX_PARENT_HOPS: usize = 32;
 
 #[derive(Debug, Clone)]
 pub struct ChatSession {
@@ -30,6 +47,28 @@ pub struct ChatRequest {
     pub prompt_tokens: Option<u64>,
     pub elapsed_ms: Option<u64>,
     pub response: Vec<Value>,
+}
+
+/// Token usage of one chat request (one user turn) aggregated from the
+/// Copilot Chat extension debug log. A single chat request in agent mode fans
+/// out into several LLM calls (one per tool-call round). VS Code itself only
+/// persists the prompt size of the *last* call as `promptTokens` and the sum
+/// of outputs as `completionTokens`, and it never persists cached tokens, so
+/// the debug log is the only local source for cache reads.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DebugLogTurnUsage {
+    /// Start time (Unix ms) of the `user_message` span.
+    pub timestamp: Option<i64>,
+    /// Prompt text recorded by the logger (possibly truncated).
+    pub prompt: Option<String>,
+    /// Number of `llm_request` spans that reported usage for this turn.
+    pub llm_requests: usize,
+    /// Sum of `inputTokens` across the turn. Includes cached tokens.
+    pub input: u64,
+    /// Sum of `outputTokens` across the turn.
+    pub output: u64,
+    /// Sum of `cachedTokens` (prompt cache reads) across the turn.
+    pub cache_read: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -270,13 +309,18 @@ pub fn to_usage_entries(session: &ChatSession, path: &Path) -> Vec<UsageEntry> {
         .into_name()
         .or_else(|| Some(session.session_id.clone()));
     let fallback_timestamp = session.creation_date.map(timestamp_to_iso);
+    let debug_log_turns = debug_log_path(path)
+        .filter(|debug_path| debug_path.is_file())
+        .map(|debug_path| read_debug_log_turns(&debug_path))
+        .unwrap_or_default();
+    let debug_log_usage = match_debug_log_turns(&session.requests, &debug_log_turns);
 
     session
         .requests
         .iter()
         .enumerate()
         .map(|(index, request)| {
-            let tokens = token_stats(request);
+            let tokens = token_stats(request, debug_log_usage.get(&index));
             let timestamp = request
                 .timestamp
                 .map(timestamp_to_iso)
@@ -563,7 +607,30 @@ fn contains_copilot_marker(value: &str) -> bool {
     value.contains("copilot")
 }
 
-fn token_stats(request: &ChatRequest) -> Option<TokenStats> {
+fn token_stats(
+    request: &ChatRequest,
+    debug_log_usage: Option<&DebugLogTurnUsage>,
+) -> Option<TokenStats> {
+    if let Some(usage) = debug_log_usage.filter(|usage| usage.llm_requests > 0) {
+        // The debug log reports `inputTokens` inclusive of cache reads (the
+        // same convention as Copilot CLI `assistant_usage_events`). The
+        // dashboard stores non-cached input and cache reads separately so
+        // pricing can bill each at its own rate.
+        let cache_read = usage.cache_read.min(usage.input);
+        let input = usage.input - cache_read;
+        let output = usage.output;
+        return Some(TokenStats {
+            input,
+            output,
+            cache_read: Some(cache_read),
+            cache_write: None,
+            cache_write_5m: None,
+            cache_write_1h: None,
+            reasoning: None,
+            total: input.saturating_add(cache_read).saturating_add(output),
+        });
+    }
+
     if request.prompt_tokens.is_none() && request.completion_tokens.is_none() {
         return None;
     }
@@ -579,6 +646,225 @@ fn token_stats(request: &ChatRequest) -> Option<TokenStats> {
         reasoning: None,
         total: input.saturating_add(output),
     })
+}
+
+/// Resolve the Copilot Chat debug log that belongs to a `chatSessions` file:
+/// `<workspace>/chatSessions/<sessionId>.jsonl` maps to
+/// `<workspace>/GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`.
+/// The path is returned even when the file does not exist so callers can
+/// include it in sync-state signatures.
+pub fn debug_log_path(session_file: &Path) -> Option<PathBuf> {
+    let session_id = session_file.file_stem()?.to_str()?;
+    let workspace_dir = session_file.parent()?.parent()?;
+    Some(
+        workspace_dir
+            .join(COPILOT_CHAT_STORAGE_DIR)
+            .join(COPILOT_CHAT_DEBUG_LOGS_DIR)
+            .join(session_id)
+            .join(COPILOT_CHAT_DEBUG_LOG_FILE),
+    )
+}
+
+/// Read a Copilot Chat debug log and aggregate LLM usage per user turn.
+/// Unreadable files yield an empty list so the caller falls back to the
+/// token fields persisted by VS Code itself.
+pub fn read_debug_log_turns(path: &Path) -> Vec<DebugLogTurnUsage> {
+    match fs::read_to_string(path) {
+        Ok(content) => parse_debug_log_turns(&content),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[derive(Debug)]
+struct DebugLogLlmRequest {
+    timestamp: Option<i64>,
+    parent_span_id: Option<String>,
+    input: u64,
+    output: u64,
+    cache_read: u64,
+}
+
+/// Aggregate `llm_request` spans of a debug log under the `user_message`
+/// span they belong to. Spans are linked to their turn by walking
+/// `parentSpanId`; spans whose chain does not end at a `user_message` are
+/// attributed to the most recent turn that started before them.
+fn parse_debug_log_turns(content: &str) -> Vec<DebugLogTurnUsage> {
+    let mut turns: Vec<DebugLogTurnUsage> = Vec::new();
+    let mut turn_index_by_span: HashMap<String, usize> = HashMap::new();
+    let mut parent_by_span: HashMap<String, String> = HashMap::new();
+    let mut llm_requests: Vec<DebugLogLlmRequest> = Vec::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<Value>(&sanitize_json_surrogates(line)) else {
+            continue;
+        };
+        let Some(kind) = event.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        let span_id = event
+            .get("spanId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let parent_span_id = event
+            .get("parentSpanId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if let (Some(span), Some(parent)) = (&span_id, &parent_span_id) {
+            parent_by_span.insert(span.clone(), parent.clone());
+        }
+        let timestamp = event.get("ts").and_then(Value::as_i64);
+        let attrs = event.get("attrs");
+
+        match kind {
+            "user_message" => {
+                let prompt = attrs
+                    .and_then(|attrs| attrs.get("content"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                if let Some(span) = span_id {
+                    turn_index_by_span.insert(span, turns.len());
+                }
+                turns.push(DebugLogTurnUsage {
+                    timestamp,
+                    prompt,
+                    ..DebugLogTurnUsage::default()
+                });
+            }
+            "llm_request" => {
+                let Some(attrs) = attrs else {
+                    continue;
+                };
+                let input = attrs.get("inputTokens").and_then(Value::as_u64);
+                let output = attrs.get("outputTokens").and_then(Value::as_u64);
+                let cache_read = attrs.get("cachedTokens").and_then(Value::as_u64);
+                if input.is_none() && output.is_none() && cache_read.is_none() {
+                    // Failed or aborted call without usage; nothing to bill.
+                    continue;
+                }
+                llm_requests.push(DebugLogLlmRequest {
+                    timestamp,
+                    parent_span_id,
+                    input: input.unwrap_or(0),
+                    output: output.unwrap_or(0),
+                    cache_read: cache_read.unwrap_or(0),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    if turns.is_empty() {
+        return turns;
+    }
+
+    for request in llm_requests {
+        let by_parent = resolve_debug_log_turn(
+            request.parent_span_id.as_deref(),
+            &parent_by_span,
+            &turn_index_by_span,
+        );
+        let index = by_parent.or_else(|| {
+            let ts = request.timestamp?;
+            turns
+                .iter()
+                .rposition(|turn| turn.timestamp.is_some_and(|start| start <= ts))
+        });
+        let Some(index) = index else {
+            continue;
+        };
+        let turn = &mut turns[index];
+        turn.llm_requests += 1;
+        turn.input = turn.input.saturating_add(request.input);
+        turn.output = turn.output.saturating_add(request.output);
+        turn.cache_read = turn.cache_read.saturating_add(request.cache_read);
+    }
+
+    turns
+}
+
+fn resolve_debug_log_turn(
+    parent_span_id: Option<&str>,
+    parent_by_span: &HashMap<String, String>,
+    turn_index_by_span: &HashMap<String, usize>,
+) -> Option<usize> {
+    let mut current = parent_span_id?;
+    for _ in 0..COPILOT_CHAT_DEBUG_LOG_MAX_PARENT_HOPS {
+        if let Some(index) = turn_index_by_span.get(current) {
+            return Some(*index);
+        }
+        current = parent_by_span.get(current)?;
+    }
+    None
+}
+
+/// Pair debug-log turns with the `requests` array of the chat session.
+/// Returns a map from request index to the aggregated usage. Matching prefers
+/// identical prompt text (allowing the logger's truncation) and breaks ties by
+/// timestamp distance; when no prompt matches, the closest request within
+/// [`COPILOT_CHAT_DEBUG_LOG_TIMESTAMP_TOLERANCE_MS`] is used.
+fn match_debug_log_turns(
+    requests: &[ChatRequest],
+    turns: &[DebugLogTurnUsage],
+) -> HashMap<usize, DebugLogTurnUsage> {
+    let mut matched: HashMap<usize, DebugLogTurnUsage> = HashMap::new();
+    if requests.is_empty() || turns.is_empty() {
+        return matched;
+    }
+
+    for turn in turns {
+        let distance = |index: usize| -> Option<i64> {
+            let request_ts = requests[index].timestamp?;
+            let turn_ts = turn.timestamp?;
+            Some((turn_ts - request_ts).abs())
+        };
+        let candidates = (0..requests.len()).filter(|index| !matched.contains_key(index));
+
+        let mut best_text: Option<(usize, i64)> = None;
+        let mut best_time: Option<(usize, i64)> = None;
+        for index in candidates {
+            let dist = distance(index);
+            if debug_log_prompt_matches(&requests[index].prompt, turn.prompt.as_deref()) {
+                let dist = dist.unwrap_or(i64::MAX);
+                if best_text.is_none_or(|(_, best)| dist < best) {
+                    best_text = Some((index, dist));
+                }
+            }
+            if let Some(dist) = dist {
+                if dist <= COPILOT_CHAT_DEBUG_LOG_TIMESTAMP_TOLERANCE_MS
+                    && best_time.is_none_or(|(_, best)| dist < best)
+                {
+                    best_time = Some((index, dist));
+                }
+            }
+        }
+
+        if let Some((index, _)) = best_text.or(best_time) {
+            matched.insert(index, turn.clone());
+        }
+    }
+
+    matched
+}
+
+fn debug_log_prompt_matches(request_prompt: &str, logged_prompt: Option<&str>) -> bool {
+    let Some(logged) = logged_prompt else {
+        return false;
+    };
+    let request_prompt = request_prompt.trim();
+    let logged = logged.trim();
+    if request_prompt.is_empty() || logged.is_empty() {
+        return false;
+    }
+    if request_prompt == logged {
+        return true;
+    }
+    logged
+        .strip_suffix(COPILOT_CHAT_DEBUG_LOG_TRUNCATED_SUFFIX)
+        .is_some_and(|prefix| !prefix.is_empty() && request_prompt.starts_with(prefix))
 }
 
 fn response_model(parts: &[Value]) -> Option<String> {
@@ -758,6 +1044,251 @@ mod tests {
         assert!(entries
             .iter()
             .all(|entry| entry.session_name.as_deref() == Some("Second prompt")));
+    }
+
+    fn request(
+        timestamp: i64,
+        prompt: &str,
+        prompt_tokens: Option<u64>,
+        completion_tokens: Option<u64>,
+    ) -> ChatRequest {
+        ChatRequest {
+            timestamp: Some(timestamp),
+            prompt: prompt.to_string(),
+            agent_id: Some("github.copilot.editsAgent".to_string()),
+            model_id: Some("copilot/gpt-5.4".to_string()),
+            completion_tokens,
+            prompt_tokens,
+            elapsed_ms: Some(1_000),
+            response: vec![serde_json::json!({
+                "kind": "markdownContent",
+                "content": "reply"
+            })],
+        }
+    }
+
+    /// Mirrors the real `GitHub.copilot-chat/debug-logs/<sid>/main.jsonl`
+    /// layout: `user_message` spans own the turn, `llm_request` spans point
+    /// back at them through `parentSpanId` (sometimes via a tool span).
+    const DEBUG_LOG_FIXTURE: &str = concat!(
+        r#"{"v":1,"ts":1783858098260,"dur":0,"sid":"abc","type":"session_start","name":"session_start","spanId":"session-start-abc","status":"ok","attrs":{"copilotVersion":"0.65.0"}}"#,
+        "\n",
+        r#"{"ts":1783858098936,"dur":0,"sid":"abc","type":"user_message","name":"user_message","spanId":"00d3","status":"ok","attrs":{"content":"幫我優化 README"}}"#,
+        "\n",
+        r#"{"ts":1783858098937,"dur":0,"sid":"abc","type":"turn_start","name":"turn_start","spanId":"turn_start-00d3-0","status":"ok","attrs":{"turnId":"0"}}"#,
+        "\n",
+        r#"{"ts":1783858100004,"dur":21078,"sid":"abc","type":"llm_request","name":"chat:gpt-5.4","spanId":"00dc","parentSpanId":"00d3","status":"ok","attrs":{"model":"gpt-5.4","debugName":"panel/editAgent","inputTokens":40446,"outputTokens":2661,"cachedTokens":11264}}"#,
+        "\n",
+        r#"{"ts":1783858121000,"dur":10,"sid":"abc","type":"tool_call","name":"tool:read_file","spanId":"00de","parentSpanId":"00d3","status":"ok","attrs":{"toolName":"read_file"}}"#,
+        "\n",
+        r#"{"ts":1783858121175,"dur":3864,"sid":"abc","type":"llm_request","name":"chat:gpt-5.4","spanId":"00e1","parentSpanId":"00de","status":"ok","attrs":{"model":"gpt-5.4","debugName":"panel/editAgent","inputTokens":42072,"outputTokens":115,"cachedTokens":40320}}"#,
+        "\n",
+        r#"{"ts":1783858125042,"dur":0,"sid":"abc","type":"turn_end","name":"turn_end","spanId":"turn_end-00d3-1","status":"ok","attrs":{"turnId":"1"}}"#,
+        "\n",
+        r#"{"ts":1783858200000,"dur":0,"sid":"abc","type":"user_message","name":"user_message","spanId":"00f0","status":"ok","attrs":{"content":"這是一段非常長的提示詞前綴[truncated]"}}"#,
+        "\n",
+        r#"{"ts":1783858200500,"dur":800,"sid":"abc","type":"llm_request","name":"chat:gpt-5.4","spanId":"00f2","parentSpanId":"missing-span","status":"error","attrs":{"model":"gpt-5.4","debugName":"panel/editAgent","error":"aborted"}}"#,
+        "\n",
+        r#"{"ts":1783858201000,"dur":1500,"sid":"abc","type":"llm_request","name":"chat:gpt-5.4","spanId":"00f3","parentSpanId":"missing-span","status":"ok","attrs":{"model":"gpt-5.4","debugName":"panel/editAgent","inputTokens":1000,"outputTokens":50,"cachedTokens":0}}"#,
+        "\n",
+        "not json at all",
+        "\n"
+    );
+
+    #[test]
+    fn debug_log_path_resolves_sibling_copilot_chat_dir() {
+        let session_file = Path::new("/data/workspaceStorage/ws1/chatSessions/abc.jsonl");
+        assert_eq!(
+            debug_log_path(session_file),
+            Some(PathBuf::from(
+                "/data/workspaceStorage/ws1/GitHub.copilot-chat/debug-logs/abc/main.jsonl"
+            ))
+        );
+        assert_eq!(
+            debug_log_path(Path::new(
+                "/data/workspaceStorage/ws1/chatSessions/abc.json"
+            )),
+            Some(PathBuf::from(
+                "/data/workspaceStorage/ws1/GitHub.copilot-chat/debug-logs/abc/main.jsonl"
+            ))
+        );
+        assert!(debug_log_path(Path::new("abc.json")).is_none());
+    }
+
+    #[test]
+    fn parses_debug_log_turns_per_user_message() {
+        let turns = parse_debug_log_turns(DEBUG_LOG_FIXTURE);
+        assert_eq!(turns.len(), 2);
+
+        // Turn 1: two LLM calls, one linked through an intermediate tool span.
+        assert_eq!(turns[0].timestamp, Some(1_783_858_098_936));
+        assert_eq!(turns[0].prompt.as_deref(), Some("幫我優化 README"));
+        assert_eq!(turns[0].llm_requests, 2);
+        assert_eq!(turns[0].input, 40_446 + 42_072);
+        assert_eq!(turns[0].output, 2_661 + 115);
+        assert_eq!(turns[0].cache_read, 11_264 + 40_320);
+
+        // Turn 2: the aborted call carries no usage and is ignored; the call
+        // with a dangling parent falls back to the latest turn by timestamp.
+        assert_eq!(turns[1].llm_requests, 1);
+        assert_eq!(turns[1].input, 1_000);
+        assert_eq!(turns[1].output, 50);
+        assert_eq!(turns[1].cache_read, 0);
+    }
+
+    #[test]
+    fn debug_log_without_user_messages_yields_no_turns() {
+        let content = concat!(
+            r#"{"v":1,"ts":1,"dur":0,"sid":"abc","type":"session_start","name":"session_start","spanId":"s","status":"ok","attrs":{}}"#,
+            "\n",
+            r#"{"ts":2,"dur":1,"sid":"abc","type":"llm_request","name":"chat:x","spanId":"l","status":"ok","attrs":{"inputTokens":5,"outputTokens":1,"cachedTokens":0}}"#,
+            "\n"
+        );
+        assert!(parse_debug_log_turns(content).is_empty());
+        assert!(parse_debug_log_turns("").is_empty());
+    }
+
+    #[test]
+    fn matches_debug_log_turns_by_prompt_then_timestamp() {
+        let requests = vec![
+            // Older request that has no debug-log counterpart at all.
+            request(1_783_850_000_000, "舊的請求", Some(10), Some(5)),
+            request(
+                1_783_858_097_242,
+                "幫我優化 README",
+                Some(42_072),
+                Some(2_776),
+            ),
+            request(
+                1_783_858_198_500,
+                "這是一段非常長的提示詞前綴，後面還有更多內容",
+                None,
+                Some(50),
+            ),
+            // Prompt differs from the logged text (e.g. slash command expansion)
+            // but the timestamp is within tolerance.
+            request(1_783_858_300_000, "/fix 這個錯誤", Some(500), Some(20)),
+        ];
+        let mut turns = parse_debug_log_turns(DEBUG_LOG_FIXTURE);
+        turns.push(DebugLogTurnUsage {
+            timestamp: Some(1_783_858_301_900),
+            prompt: Some("Fix the following error".to_string()),
+            llm_requests: 1,
+            input: 600,
+            output: 20,
+            cache_read: 100,
+        });
+        // A turn far away from every request and with unknown text stays unmatched.
+        turns.push(DebugLogTurnUsage {
+            timestamp: Some(1_790_000_000_000),
+            prompt: Some("孤兒回合".to_string()),
+            llm_requests: 1,
+            input: 1,
+            output: 1,
+            cache_read: 0,
+        });
+
+        let matched = match_debug_log_turns(&requests, &turns);
+        assert_eq!(matched.len(), 3);
+        assert!(!matched.contains_key(&0));
+        assert_eq!(matched[&1].cache_read, 11_264 + 40_320);
+        assert_eq!(matched[&2].input, 1_000);
+        assert_eq!(matched[&3].cache_read, 100);
+    }
+
+    #[test]
+    fn to_usage_entries_prefers_debug_log_usage_for_cache_reads() {
+        let root = std::env::temp_dir().join(format!(
+            "tui-vscode-debug-log-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let workspace = root.join("workspaceStorage").join("ws1");
+        let chat_sessions = workspace.join("chatSessions");
+        let debug_dir = workspace
+            .join(COPILOT_CHAT_STORAGE_DIR)
+            .join(COPILOT_CHAT_DEBUG_LOGS_DIR)
+            .join("abc");
+        fs::create_dir_all(&chat_sessions).expect("chatSessions dir");
+        fs::create_dir_all(&debug_dir).expect("debug-logs dir");
+        let session_file = chat_sessions.join("abc.jsonl");
+        fs::write(&session_file, "").expect("session placeholder");
+        fs::write(
+            debug_dir.join(COPILOT_CHAT_DEBUG_LOG_FILE),
+            DEBUG_LOG_FIXTURE,
+        )
+        .expect("debug log");
+
+        let session = ChatSession {
+            session_id: "abc".to_string(),
+            creation_date: Some(1_783_858_090_000),
+            initial_location: Some("panel".to_string()),
+            working_directory: Some("/tmp/project".to_string()),
+            responder_username: Some("GitHub Copilot".to_string()),
+            requests: vec![
+                request(
+                    1_783_858_097_242,
+                    "幫我優化 README",
+                    Some(42_072),
+                    Some(2_776),
+                ),
+                request(
+                    1_783_858_198_500,
+                    "這是一段非常長的提示詞前綴，後面還有更多內容",
+                    None,
+                    Some(50),
+                ),
+                // No debug-log turn: falls back to VS Code's own token fields.
+                request(1_783_859_000_000, "沒有除錯記錄的回合", Some(300), Some(30)),
+            ],
+        };
+
+        let entries = to_usage_entries(&session, &session_file);
+        assert_eq!(entries.len(), 3);
+
+        let first = entries[0].tokens.as_ref().expect("turn 1 tokens");
+        assert_eq!(first.cache_read, Some(11_264 + 40_320));
+        assert_eq!(first.input, (40_446 - 11_264) + (42_072 - 40_320));
+        assert_eq!(first.output, 2_776);
+        assert_eq!(first.total, first.input + 51_584 + 2_776);
+        assert_eq!(
+            entries[0].delta_tokens.as_ref().map(|tokens| tokens.total),
+            Some(first.total)
+        );
+
+        let second = entries[1].tokens.as_ref().expect("turn 2 tokens");
+        assert_eq!(second.input, 1_000);
+        assert_eq!(second.cache_read, Some(0));
+        assert_eq!(second.total, 1_050);
+
+        let third = entries[2].tokens.as_ref().expect("turn 3 tokens");
+        assert_eq!(third.input, 300);
+        assert_eq!(third.output, 30);
+        assert_eq!(third.cache_read, None);
+        assert_eq!(third.total, 330);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn missing_debug_log_keeps_vscode_token_fields() {
+        let session = ChatSession {
+            session_id: "no-debug-log".to_string(),
+            creation_date: Some(1_783_858_090_000),
+            initial_location: None,
+            working_directory: None,
+            responder_username: Some("GitHub Copilot".to_string()),
+            requests: vec![request(1_783_858_097_242, "hello", Some(10), Some(5))],
+        };
+        let entries = to_usage_entries(
+            &session,
+            Path::new("/nonexistent/workspaceStorage/ws/chatSessions/no-debug-log.jsonl"),
+        );
+        let tokens = entries[0].tokens.as_ref().expect("tokens");
+        assert_eq!(
+            (tokens.input, tokens.output, tokens.cache_read, tokens.total),
+            (10, 5, None, 15)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 摘要

修復 GitHub Copilot Chat（VS Code）Session 在戰情室的「快取讀取 Token」永遠顯示 0、「Token 消耗趨勢與快取狀況」圖表沒有快取讀取長條的問題。

Fixes #41

## 問題根因

- VS Code 寫入 `workspaceStorage/<workspace>/chatSessions/<sessionId>.jsonl` 的聊天 Session 只保存每個請求最後一次模型呼叫的 `promptTokens` 與累計的 `completionTokens`，從未記錄 Prompt Cache 快取讀取數。
- `src/vscode.rs` 的 `token_stats()` 因此把 `cache_read` 寫死為 `None`，VS Code 來源的所有回合快取讀取都是 0。
- Copilot Chat 擴充功能會在同一個工作區目錄下寫入 `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl`，每個 `llm_request` span 帶有 `inputTokens` / `outputTokens` / `cachedTokens`，並經 `parentSpanId` 連回該回合的 `user_message` span。這是 VS Code Copilot Chat 目前唯一能在本機取得快取讀取數的來源。

## 使用者可見變更

- 有除錯記錄的 VS Code Copilot Chat 回合，日報卡片、圖表與 Session 清單會顯示快取讀取 Token，成本估算依快取讀取費率計價。
- 這些回合的輸入 Token 改為該回合所有模型呼叫的非快取輸入總和（原本只採用最後一次呼叫的 `promptTokens`），輸出 Token 為各呼叫輸出總和，數值更貼近實際消耗。
- 沒有除錯記錄的回合（未啟用 `github.copilot.chat.agentDebugLog.fileLogging.enabled`，或超過預設保留的 50 個 Session）行為完全不變，快取讀取仍為 0。README 五種語系已補充說明。

## 變更內容

- `src/vscode.rs`：新增 `DebugLogTurnUsage`、`debug_log_path()`、`read_debug_log_turns()` / `parse_debug_log_turns()`（沿 `parentSpanId` 鏈歸屬回合，斷鏈時依時間戳回退）、`match_debug_log_turns()`（優先比對提示文字並支援 `[truncated]` 前綴，其次 120 秒內時間戳），`token_stats()` 以除錯記錄加總計算並拆分非快取輸入 / 快取讀取 / 輸出。
- `src/db.rs`：VS Code 同步狀態簽章納入除錯記錄的大小與修改時間，確保擴充功能稍後刷寫的除錯記錄會在下一次同步被補上。
- README ×5、`CHANGELOG.md`：補充快取讀取來源、設定、保留限制與回退行為。

## 資料庫 / 環境變數影響

- 無資料庫結構、環境變數或安裝流程變更。既有 VS Code Session 會因簽章改變在下一次同步時重新計算 Token。

## 驗證項目

- `cargo build` / `cargo build --release`：0 warnings、0 errors。
- `cargo test`：227 passed、0 failed（新增 7 個單元測試）；`tests/cli.rs` 1 passed。
- `cargo clippy --all-targets --all-features`：0 warnings。
- `cargo fmt --check`：通過。
- 手動驗證：以暫存 `INSIGHTS_DIR` 啟動並掃描本機 VS Code Stable 與 Insiders 真實資料，95 筆 `vscode-chat` 中 11 筆取得快取讀取 Token，各回合數值與以 Python 獨立加總 `main.jsonl` 的結果完全一致。
- 手動驗證：`GET /api/copilot/usage/2026-07-12` 的 `summary.total_cache_read_tokens` 回傳 51,584。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
