### PR TITLE
feat(scripts): 支援 Windows 常駐服務安裝功能與背景排程執行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             # shellcheck disable=SC2016
             pwsh -NoProfile -Command '
               $ErrorActionPreference = "Stop"
-              foreach ($f in @("scripts/install.ps1", "scripts/get.ps1")) {
+              foreach ($f in @("scripts/install.ps1", "scripts/get.ps1", "scripts/run-service.ps1")) {
                 $errors = $null
                 [void][System.Management.Automation.Language.Parser]::ParseFile($f, [ref]$null, [ref]$errors)
                 if ($errors.Count -gt 0) {

--- a/README.en.md
+++ b/README.en.md
@@ -613,6 +613,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if (-not $Task) {
     $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+    if ($Task) {
+        $TaskName = "TokenUsageInsights"
+    }
 }
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {

--- a/README.en.md
+++ b/README.en.md
@@ -583,7 +583,7 @@ This installs `com.tokenusageinsights.plist` into `~/Library/LaunchAgents/` and 
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
-This registers the `TokenUsageInsights` task in Windows Task Scheduler and starts it immediately; it starts automatically at user logon in the background, with logs in `%LOCALAPPDATA%\TokenUsageInsights\logs\`.
+This registers the `TokenUsageInsights_<username>` task in Windows Task Scheduler for the current user and starts it immediately; it starts automatically at user logon in the background, with logs in the installation `logs\` directory (default `%LOCALAPPDATA%\TokenUsageInsights\logs\`).
 
 ### Manage the service
 
@@ -607,71 +607,82 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell:
 
 ```powershell
-# Check status (Task Scheduler or background process)
-Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
-
-# View logs (supports custom -InstallDir)
+# Resolve installation directory (defaults to %LOCALAPPDATA%\TokenUsageInsights, or dynamically resolved from task/shortcut)
+$TaskName = if ($env:USERNAME) { "TokenUsageInsights_$env:USERNAME" } else { "TokenUsageInsights" }
 $InstallDir = $null
-$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+$Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $Task) {
+    $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+}
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
             $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
             $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
+        } elseif ($Action.WorkingDirectory) {
+            $InstallDir = $Action.WorkingDirectory
+            break
         }
     }
 }
-if (-not $InstallDir) {
-    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-    if (!(Test-Path $StartupShortcut)) {
-        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-    }
-    if (Test-Path $StartupShortcut) {
-        $WshShell = New-Object -ComObject WScript.Shell
-        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
-            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
-        } elseif ($Shortcut.WorkingDirectory) {
-            $InstallDir = $Shortcut.WorkingDirectory
-        }
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
+    if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+        $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+        $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
+    } elseif ($Shortcut.WorkingDirectory) {
+        $InstallDir = $Shortcut.WorkingDirectory
     }
 }
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+
+# Check service status (Task Scheduler or background process)
+Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | Select-Object ProcessId, Name, CommandLine
+
+# View logs
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
-# Restart service (compatible with Task Scheduler and Startup folder mode)
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-}
-if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
-    Start-ScheduledTask -TaskName "TokenUsageInsights"
+# Restart service (scoped to this install directory; compatible with Task Scheduler and Startup folder modes)
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName $TaskName
 } elseif (Test-Path $StartupShortcut) {
     Start-Process $StartupShortcut
 }
 
-# Stop service
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+# Stop service (scoped to this install directory)
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # Unregister service
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+if (Test-Path $StartupShortcut) {
+    Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
-Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 
 * * *

--- a/README.en.md
+++ b/README.en.md
@@ -646,12 +646,14 @@ if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+$TargetExe = "$InstallDir\token-usage-insights.exe".ToLowerInvariant().Replace('/', '\')
+$EscapedDir = [regex]::Escape($InstallDir)
 
 # Check service status (Task Scheduler or background process)
 Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | Select-Object ProcessId, Name, CommandLine
 
 # View logs
@@ -660,8 +662,8 @@ Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50
 # Restart service (scoped to this install directory; compatible with Task Scheduler and Startup folder modes)
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName $TaskName
@@ -672,8 +674,8 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
 # Stop service (scoped to this install directory)
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # Unregister service
@@ -683,8 +685,8 @@ if (Test-Path $StartupShortcut) {
     Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -623,7 +623,12 @@ Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # Unregister service
-Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 ```
 
 * * *

--- a/README.en.md
+++ b/README.en.md
@@ -613,15 +613,18 @@ Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # View logs (auto-detect the installed InstallDir)
 $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$ResolvedInstallDir = $false
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
             break
         }
     }
-} else {
+}
+if (-not $ResolvedInstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
@@ -630,6 +633,7 @@ if ($Task -and $Task.Actions) {
         $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
         }
     }
 }

--- a/README.en.md
+++ b/README.en.md
@@ -607,16 +607,21 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell:
 
 ```powershell
-# Check status
-Get-ScheduledTask -TaskName "TokenUsageInsights"
+# Check status (Task Scheduler or background process)
+Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # View logs
 Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
 
-# Restart service
+# Restart service (compatible with Task Scheduler and Startup folder mode)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-Start-ScheduledTask -TaskName "TokenUsageInsights"
+if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName "TokenUsageInsights"
+} else {
+    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+}
 
 # Stop service
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
@@ -629,6 +634,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 
 * * *

--- a/README.en.md
+++ b/README.en.md
@@ -611,31 +611,34 @@ Windows PowerShell:
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# View logs (auto-detect the installed InstallDir)
-$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
-$ResolvedInstallDir = $false
+# View logs (supports custom -InstallDir)
+$InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
             break
         }
     }
 }
-if (-not $ResolvedInstallDir) {
+if (-not $InstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
     }
     if (Test-Path $StartupShortcut) {
-        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        $WshShell = New-Object -ComObject WScript.Shell
+        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
+        } elseif ($Shortcut.WorkingDirectory) {
+            $InstallDir = $Shortcut.WorkingDirectory
         }
     }
+}
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 

--- a/README.en.md
+++ b/README.en.md
@@ -616,6 +616,7 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 
 # Restart service (compatible with Task Scheduler and Startup folder mode)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
 if (!(Test-Path $StartupShortcut)) {
@@ -629,6 +630,7 @@ if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContin
 
 # Stop service
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # Unregister service
@@ -638,6 +640,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -617,10 +617,14 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 # Restart service (compatible with Task Scheduler and Startup folder mode)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
 if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName "TokenUsageInsights"
-} else {
-    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+} elseif (Test-Path $StartupShortcut) {
+    Start-Process $StartupShortcut
 }
 
 # Stop service

--- a/README.en.md
+++ b/README.en.md
@@ -616,8 +616,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
-        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
         }
     }
@@ -630,8 +631,9 @@ if (-not $InstallDir) {
     if (Test-Path $StartupShortcut) {
         $WshShell = New-Object -ComObject WScript.Shell
         $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
         } elseif ($Shortcut.WorkingDirectory) {
             $InstallDir = $Shortcut.WorkingDirectory
         }

--- a/README.en.md
+++ b/README.en.md
@@ -611,8 +611,29 @@ Windows PowerShell:
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# View logs
-Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+# View logs (auto-detect the installed InstallDir)
+$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+if ($Task -and $Task.Actions) {
+    foreach ($Action in @($Task.Actions)) {
+        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            break
+        }
+    }
+} else {
+    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+    if (!(Test-Path $StartupShortcut)) {
+        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+    }
+    if (Test-Path $StartupShortcut) {
+        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        }
+    }
+}
+Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
 # Restart service (compatible with Task Scheduler and Startup folder mode)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue

--- a/README.en.md
+++ b/README.en.md
@@ -569,13 +569,61 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 
 This downloads the installed version and immediately enables `token-usage-insights.service`; you do not need to build or edit a systemd file yourself.
 
+### macOS: install and enable the launchd LaunchAgent with one command
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
+```
+
+This installs `com.tokenusageinsights.plist` into `~/Library/LaunchAgents/` and loads it immediately; stdout and stderr logs are located in `~/Library/Logs/`.
+
+### Windows: install and enable background service with one command (Task Scheduler)
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+```
+
+This registers the `TokenUsageInsights` task in Windows Task Scheduler and starts it immediately; it starts automatically at user logon in the background, with logs in `%LOCALAPPDATA%\TokenUsageInsights\logs\`.
+
 ### Manage the service
+
+Linux:
 
 ```bash
 systemctl --user status token-usage-insights.service
 journalctl --user -u token-usage-insights.service -n 50 -f
 systemctl --user restart token-usage-insights.service
 systemctl --user stop token-usage-insights.service
+```
+
+macOS:
+
+```bash
+launchctl print gui/$(id -u)/com.tokenusageinsights
+launchctl kickstart -k gui/$(id -u)/com.tokenusageinsights
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.plist
+```
+
+Windows PowerShell:
+
+```powershell
+# Check status
+Get-ScheduledTask -TaskName "TokenUsageInsights"
+
+# View logs
+Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+
+# Restart service
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-ScheduledTask -TaskName "TokenUsageInsights"
+
+# Stop service
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+
+# Unregister service
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
 ```
 
 * * *
@@ -594,7 +642,7 @@ Linux / macOS:
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash
 ```
 
-To install and enable the systemd user service at the same time on Linux:
+To install and enable the background service at the same time (systemd on Linux; launchd on macOS):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
@@ -604,6 +652,12 @@ Windows PowerShell:
 
 ```powershell
 irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1 | iex
+```
+
+To install and enable the background service at the same time on Windows:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
 After installation, run (on Linux/macOS, confirm that `bin_dir` is on `PATH`; Windows creates a `.cmd` shim):
@@ -635,7 +689,7 @@ If you do not want to execute a remote script directly, download the archive for
 - Frontend assets in `static/`
 - The model pricing table `pricing.csv`
 - Status Line and service scripts in `shell/`
-- The `scripts/` directory (including `install.sh`, `install.ps1`, `get.sh`, and `get.ps1`)
+- The `scripts/` directory (including `install.sh`, `install.ps1`, `get.sh`, `get.ps1`, and `run-service.ps1`)
 - README, LICENSE, and VERSION
 
 Linux or macOS:
@@ -646,7 +700,7 @@ cd token-usage-insights-<tag>-<target>
 ./install.sh
 ```
 
-To install and enable the systemd user service on Linux:
+To install and enable the background service (systemd on Linux; launchd on macOS):
 
 ```bash
 ./install.sh --service
@@ -658,6 +712,12 @@ Windows:
 Expand-Archive token-usage-insights-<tag>-x86_64-pc-windows-msvc.zip
 cd token-usage-insights-<tag>-x86_64-pc-windows-msvc
 powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+To install and enable the background service on Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Service
 ```
 
 Custom Windows installation location and port:

--- a/README.ja.md
+++ b/README.ja.md
@@ -613,6 +613,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if (-not $Task) {
     $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+    if ($Task) {
+        $TaskName = "TokenUsageInsights"
+    }
 }
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {

--- a/README.ja.md
+++ b/README.ja.md
@@ -616,6 +616,7 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 
 # サービスを再起動（タスクスケジューラとスタートアップフォルダの両方に対応）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
 if (!(Test-Path $StartupShortcut)) {
@@ -629,6 +630,7 @@ if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContin
 
 # サービスを停止
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 常駐サービスを登録解除
@@ -638,6 +640,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -623,7 +623,12 @@ Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 常駐サービスを登録解除
-Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 ```
 
 * * *

--- a/README.ja.md
+++ b/README.ja.md
@@ -569,13 +569,61 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 
 これはインストール版をダウンロードして `token-usage-insights.service` を直ちに有効化します。systemd ファイルを自分でビルドまたは編集する必要はありません。
 
+### macOS：1 行で launchd LaunchAgent をインストールして有効化
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
+```
+
+これは `com.tokenusageinsights.plist` を `~/Library/LaunchAgents/` にインストールして直ちにロードします。標準出力とエラーログは `~/Library/Logs/` に出力されます。
+
+### Windows：1 行でバックグラウンド常駐サービス（タスクスケジューラ）をインストールして有効化
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+```
+
+これは Windows タスクスケジューラ（Task Scheduler）に `TokenUsageInsights` タスクを登録して直ちに起動します。ユーザーログイン時に自動的にバックグラウンドで実行され、ログは `%LOCALAPPDATA%\TokenUsageInsights\logs\` に出力されます。
+
 ### サービスを管理
+
+Linux：
 
 ```bash
 systemctl --user status token-usage-insights.service
 journalctl --user -u token-usage-insights.service -n 50 -f
 systemctl --user restart token-usage-insights.service
 systemctl --user stop token-usage-insights.service
+```
+
+macOS：
+
+```bash
+launchctl print gui/$(id -u)/com.tokenusageinsights
+launchctl kickstart -k gui/$(id -u)/com.tokenusageinsights
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.plist
+```
+
+Windows PowerShell：
+
+```powershell
+# サービス状態を確認
+Get-ScheduledTask -TaskName "TokenUsageInsights"
+
+# ログをリアルタイム確認
+Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+
+# サービスを再起動
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-ScheduledTask -TaskName "TokenUsageInsights"
+
+# サービスを停止
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+
+# 常駐サービスを登録解除
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
 ```
 
 * * *
@@ -594,7 +642,7 @@ Linux / macOS：
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash
 ```
 
-Linux で systemd ユーザーサービスも同時にインストールして有効化する場合：
+Linux（systemd user service）または macOS（launchd LaunchAgent）で常駐サービスも同時にインストールして有効化する場合：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
@@ -604,6 +652,12 @@ Windows PowerShell：
 
 ```powershell
 irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1 | iex
+```
+
+Windows PowerShell で常駐サービスも同時にインストールして有効化する場合：
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
 インストール後に実行します（Linux/macOS では `bin_dir` が `PATH` に含まれることを確認してください。Windows では `.cmd` shim が作成されます）：
@@ -635,7 +689,7 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/doggy8088/TokenUsageIns
 - `static/` のフロントエンドアセット
 - モデル料金表 `pricing.csv`
 - `shell/` の Status Line およびサービススクリプト
-- `scripts/` ディレクトリ（`install.sh`、`install.ps1`、`get.sh`、`get.ps1` を含む）
+- `scripts/` ディレクトリ（`install.sh`、`install.ps1`、`get.sh`、`get.ps1`、`run-service.ps1` を含む）
 - README、LICENSE、VERSION
 
 Linux または macOS：
@@ -646,7 +700,7 @@ cd token-usage-insights-<tag>-<target>
 ./install.sh
 ```
 
-Linux で systemd ユーザーサービスをインストールして有効化する場合：
+Linux（systemd user service）または macOS（launchd LaunchAgent）で常駐サービスをインストールして有効化する場合：
 
 ```bash
 ./install.sh --service
@@ -658,6 +712,12 @@ Windows：
 Expand-Archive token-usage-insights-<tag>-x86_64-pc-windows-msvc.zip
 cd token-usage-insights-<tag>-x86_64-pc-windows-msvc
 powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+Windows でバックグラウンド常駐サービスをインストールして有効化する場合：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Service
 ```
 
 Windows のインストール先とポートをカスタマイズ：

--- a/README.ja.md
+++ b/README.ja.md
@@ -611,8 +611,29 @@ Windows PowerShell：
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# ログをリアルタイム確認
-Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+# ログをリアルタイム確認（実際の InstallDir を自動判定）
+$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+if ($Task -and $Task.Actions) {
+    foreach ($Action in @($Task.Actions)) {
+        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            break
+        }
+    }
+} else {
+    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+    if (!(Test-Path $StartupShortcut)) {
+        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+    }
+    if (Test-Path $StartupShortcut) {
+        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        }
+    }
+}
+Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
 # サービスを再起動（タスクスケジューラとスタートアップフォルダの両方に対応）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue

--- a/README.ja.md
+++ b/README.ja.md
@@ -646,12 +646,14 @@ if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+$TargetExe = "$InstallDir\token-usage-insights.exe".ToLowerInvariant().Replace('/', '\')
+$EscapedDir = [regex]::Escape($InstallDir)
 
 # サービス状態を確認（タスクスケジューラまたはバックグラウンドプロセス）
 Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | Select-Object ProcessId, Name, CommandLine
 
 # ログをリアルタイム確認
@@ -660,8 +662,8 @@ Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50
 # サービスを再起動（このインストールディレクトリに限定、タスクスケジューラとスタートアップフォルダの両方に対応）
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName $TaskName
@@ -672,8 +674,8 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
 # サービスを停止（このインストールディレクトリに限定）
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 常駐サービスを登録解除
@@ -683,8 +685,8 @@ if (Test-Path $StartupShortcut) {
     Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -613,15 +613,18 @@ Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # ログをリアルタイム確認（実際の InstallDir を自動判定）
 $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$ResolvedInstallDir = $false
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
             break
         }
     }
-} else {
+}
+if (-not $ResolvedInstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
@@ -630,6 +633,7 @@ if ($Task -and $Task.Actions) {
         $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
         }
     }
 }

--- a/README.ja.md
+++ b/README.ja.md
@@ -607,16 +607,21 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell：
 
 ```powershell
-# サービス状態を確認
-Get-ScheduledTask -TaskName "TokenUsageInsights"
+# サービス状態を確認（タスクスケジューラまたはバックグラウンドプロセス）
+Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # ログをリアルタイム確認
 Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
 
-# サービスを再起動
+# サービスを再起動（タスクスケジューラとスタートアップフォルダの両方に対応）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-Start-ScheduledTask -TaskName "TokenUsageInsights"
+if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName "TokenUsageInsights"
+} else {
+    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+}
 
 # サービスを停止
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
@@ -629,6 +634,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 
 * * *

--- a/README.ja.md
+++ b/README.ja.md
@@ -583,7 +583,7 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
-これは Windows タスクスケジューラ（Task Scheduler）に `TokenUsageInsights` タスクを登録して直ちに起動します。ユーザーログイン時に自動的にバックグラウンドで実行され、ログは `%LOCALAPPDATA%\TokenUsageInsights\logs\` に出力されます。
+これは Windows タスクスケジューラ（Task Scheduler）に現在のユーザー専用の `TokenUsageInsights_<username>` タスクを登録して直ちに起動します。ユーザーログイン時に自動的にバックグラウンドで実行され、標準出力とエラーログはインストールディレクトリ配下の `logs\`（デフォルトは `%LOCALAPPDATA%\TokenUsageInsights\logs\`）に出力されます。
 
 ### サービスを管理
 
@@ -607,71 +607,82 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell：
 
 ```powershell
-# サービス状態を確認（タスクスケジューラまたはバックグラウンドプロセス）
-Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
-
-# ログをリアルタイム確認（カスタム -InstallDir 対応）
+# インストールディレクトリを解決（デフォルトは %LOCALAPPDATA%\TokenUsageInsights、またはタスク／ショートカットから動的取得）
+$TaskName = if ($env:USERNAME) { "TokenUsageInsights_$env:USERNAME" } else { "TokenUsageInsights" }
 $InstallDir = $null
-$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+$Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $Task) {
+    $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+}
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
             $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
             $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
+        } elseif ($Action.WorkingDirectory) {
+            $InstallDir = $Action.WorkingDirectory
+            break
         }
     }
 }
-if (-not $InstallDir) {
-    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-    if (!(Test-Path $StartupShortcut)) {
-        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-    }
-    if (Test-Path $StartupShortcut) {
-        $WshShell = New-Object -ComObject WScript.Shell
-        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
-            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
-        } elseif ($Shortcut.WorkingDirectory) {
-            $InstallDir = $Shortcut.WorkingDirectory
-        }
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
+    if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+        $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+        $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
+    } elseif ($Shortcut.WorkingDirectory) {
+        $InstallDir = $Shortcut.WorkingDirectory
     }
 }
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+
+# サービス状態を確認（タスクスケジューラまたはバックグラウンドプロセス）
+Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | Select-Object ProcessId, Name, CommandLine
+
+# ログをリアルタイム確認
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
-# サービスを再起動（タスクスケジューラとスタートアップフォルダの両方に対応）
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-}
-if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
-    Start-ScheduledTask -TaskName "TokenUsageInsights"
+# サービスを再起動（このインストールディレクトリに限定、タスクスケジューラとスタートアップフォルダの両方に対応）
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName $TaskName
 } elseif (Test-Path $StartupShortcut) {
     Start-Process $StartupShortcut
 }
 
-# サービスを停止
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+# サービスを停止（このインストールディレクトリに限定）
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 常駐サービスを登録解除
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+if (Test-Path $StartupShortcut) {
+    Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
-Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 
 * * *

--- a/README.ja.md
+++ b/README.ja.md
@@ -617,10 +617,14 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 # サービスを再起動（タスクスケジューラとスタートアップフォルダの両方に対応）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
 if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName "TokenUsageInsights"
-} else {
-    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+} elseif (Test-Path $StartupShortcut) {
+    Start-Process $StartupShortcut
 }
 
 # サービスを停止

--- a/README.ja.md
+++ b/README.ja.md
@@ -616,8 +616,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
-        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
         }
     }
@@ -630,8 +631,9 @@ if (-not $InstallDir) {
     if (Test-Path $StartupShortcut) {
         $WshShell = New-Object -ComObject WScript.Shell
         $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
         } elseif ($Shortcut.WorkingDirectory) {
             $InstallDir = $Shortcut.WorkingDirectory
         }

--- a/README.ja.md
+++ b/README.ja.md
@@ -611,31 +611,34 @@ Windows PowerShell：
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# ログをリアルタイム確認（実際の InstallDir を自動判定）
-$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
-$ResolvedInstallDir = $false
+# ログをリアルタイム確認（カスタム -InstallDir 対応）
+$InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
             break
         }
     }
 }
-if (-not $ResolvedInstallDir) {
+if (-not $InstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
     }
     if (Test-Path $StartupShortcut) {
-        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        $WshShell = New-Object -ComObject WScript.Shell
+        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
+        } elseif ($Shortcut.WorkingDirectory) {
+            $InstallDir = $Shortcut.WorkingDirectory
         }
     }
+}
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -613,6 +613,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if (-not $Task) {
     $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+    if ($Task) {
+        $TaskName = "TokenUsageInsights"
+    }
 }
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {

--- a/README.ko.md
+++ b/README.ko.md
@@ -617,10 +617,14 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 # 서비스 다시 시작(작업 스케줄러 및 시작프로그램 모드 자동 호환)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
 if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName "TokenUsageInsights"
-} else {
-    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+} elseif (Test-Path $StartupShortcut) {
+    Start-Process $StartupShortcut
 }
 
 # 서비스 중지

--- a/README.ko.md
+++ b/README.ko.md
@@ -583,7 +583,7 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
-이 명령은 Windows 작업 스케줄러(Task Scheduler)에 `TokenUsageInsights` 작업을 등록하고 즉시 시작합니다. 사용자가 로그인할 때마다 백그라운드에서 자동으로 실행되며 로그는 `%LOCALAPPDATA%\TokenUsageInsights\logs\`에 저장됩니다.
+이 명령은 Windows 작업 스케줄러(Task Scheduler)에 현재 사용자 전용 `TokenUsageInsights_<username>` 작업을 등록하고 즉시 시작합니다. 사용자가 로그인할 때마다 백그라운드에서 자동으로 실행되며 표준 출력 및 오류 로그는 설치 디렉터리 하위의 `logs\`(기본값은 `%LOCALAPPDATA%\TokenUsageInsights\logs\`)에 저장됩니다.
 
 ### 서비스 관리
 
@@ -607,71 +607,82 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell:
 
 ```powershell
-# 서비스 상태 확인(작업 스케줄러 또는 백그라운드 프로세스)
-Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
-
-# 실시간 로그 확인(사용자 지정 -InstallDir 지원)
+# 설치 디렉터리 확인(기본값은 %LOCALAPPDATA%\TokenUsageInsights, 또는 작업/바로 가기에서 동적 확인)
+$TaskName = if ($env:USERNAME) { "TokenUsageInsights_$env:USERNAME" } else { "TokenUsageInsights" }
 $InstallDir = $null
-$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+$Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $Task) {
+    $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+}
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
             $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
             $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
+        } elseif ($Action.WorkingDirectory) {
+            $InstallDir = $Action.WorkingDirectory
+            break
         }
     }
 }
-if (-not $InstallDir) {
-    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-    if (!(Test-Path $StartupShortcut)) {
-        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-    }
-    if (Test-Path $StartupShortcut) {
-        $WshShell = New-Object -ComObject WScript.Shell
-        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
-            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
-        } elseif ($Shortcut.WorkingDirectory) {
-            $InstallDir = $Shortcut.WorkingDirectory
-        }
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
+    if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+        $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+        $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
+    } elseif ($Shortcut.WorkingDirectory) {
+        $InstallDir = $Shortcut.WorkingDirectory
     }
 }
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+
+# 서비스 상태 확인(작업 스케줄러 또는 백그라운드 프로세스)
+Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | Select-Object ProcessId, Name, CommandLine
+
+# 실시간 로그 확인
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
-# 서비스 다시 시작(작업 스케줄러 및 시작프로그램 모드 자동 호환)
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-}
-if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
-    Start-ScheduledTask -TaskName "TokenUsageInsights"
+# 서비스 다시 시작(해당 설치 디렉터리에 한정, 작업 스케줄러 및 시작프로그램 모드 자동 호환)
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName $TaskName
 } elseif (Test-Path $StartupShortcut) {
     Start-Process $StartupShortcut
 }
 
-# 서비스 중지
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+# 서비스 중지(해당 설치 디렉터리에 한정)
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 상주 서비스 등록 해제
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+if (Test-Path $StartupShortcut) {
+    Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
-Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 
 * * *

--- a/README.ko.md
+++ b/README.ko.md
@@ -623,7 +623,12 @@ Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 상주 서비스 등록 해제
-Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 ```
 
 * * *

--- a/README.ko.md
+++ b/README.ko.md
@@ -646,12 +646,14 @@ if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+$TargetExe = "$InstallDir\token-usage-insights.exe".ToLowerInvariant().Replace('/', '\')
+$EscapedDir = [regex]::Escape($InstallDir)
 
 # 서비스 상태 확인(작업 스케줄러 또는 백그라운드 프로세스)
 Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | Select-Object ProcessId, Name, CommandLine
 
 # 실시간 로그 확인
@@ -660,8 +662,8 @@ Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50
 # 서비스 다시 시작(해당 설치 디렉터리에 한정, 작업 스케줄러 및 시작프로그램 모드 자동 호환)
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName $TaskName
@@ -672,8 +674,8 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
 # 서비스 중지(해당 설치 디렉터리에 한정)
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 상주 서비스 등록 해제
@@ -683,8 +685,8 @@ if (Test-Path $StartupShortcut) {
     Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -613,15 +613,18 @@ Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # 실시간 로그 확인(실제 InstallDir 자동 감지)
 $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$ResolvedInstallDir = $false
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
             break
         }
     }
-} else {
+}
+if (-not $ResolvedInstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
@@ -630,6 +633,7 @@ if ($Task -and $Task.Actions) {
         $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
         }
     }
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -611,31 +611,34 @@ Windows PowerShell:
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# 실시간 로그 확인(실제 InstallDir 자동 감지)
-$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
-$ResolvedInstallDir = $false
+# 실시간 로그 확인(사용자 지정 -InstallDir 지원)
+$InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
             break
         }
     }
 }
-if (-not $ResolvedInstallDir) {
+if (-not $InstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
     }
     if (Test-Path $StartupShortcut) {
-        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        $WshShell = New-Object -ComObject WScript.Shell
+        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
+        } elseif ($Shortcut.WorkingDirectory) {
+            $InstallDir = $Shortcut.WorkingDirectory
         }
     }
+}
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -569,13 +569,61 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 
 이 명령은 설치 버전을 다운로드하고 `token-usage-insights.service`를 즉시 활성화합니다. systemd 파일을 직접 빌드하거나 수정할 필요가 없습니다.
 
+### macOS: 한 줄로 launchd LaunchAgent 설치 및 활성화
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
+```
+
+이 명령은 `com.tokenusageinsights.plist`를 `~/Library/LaunchAgents/`에 설치하고 즉시 로드합니다. 표준 출력과 오류 로그는 `~/Library/Logs/`에 저장됩니다.
+
+### Windows: 한 줄로 백그라운드 상주 서비스(작업 스케줄러) 설치 및 활성화
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+```
+
+이 명령은 Windows 작업 스케줄러(Task Scheduler)에 `TokenUsageInsights` 작업을 등록하고 즉시 시작합니다. 사용자가 로그인할 때마다 백그라운드에서 자동으로 실행되며 로그는 `%LOCALAPPDATA%\TokenUsageInsights\logs\`에 저장됩니다.
+
 ### 서비스 관리
+
+Linux:
 
 ```bash
 systemctl --user status token-usage-insights.service
 journalctl --user -u token-usage-insights.service -n 50 -f
 systemctl --user restart token-usage-insights.service
 systemctl --user stop token-usage-insights.service
+```
+
+macOS:
+
+```bash
+launchctl print gui/$(id -u)/com.tokenusageinsights
+launchctl kickstart -k gui/$(id -u)/com.tokenusageinsights
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.plist
+```
+
+Windows PowerShell:
+
+```powershell
+# 서비스 상태 확인
+Get-ScheduledTask -TaskName "TokenUsageInsights"
+
+# 실시간 로그 확인
+Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+
+# 서비스 다시 시작
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-ScheduledTask -TaskName "TokenUsageInsights"
+
+# 서비스 중지
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+
+# 상주 서비스 등록 해제
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
 ```
 
 * * *
@@ -594,7 +642,7 @@ Linux / macOS:
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash
 ```
 
-Linux에서 systemd 사용자 서비스를 함께 설치하고 활성화하려면:
+Linux(systemd user service) 또는 macOS(launchd LaunchAgent)에서 상주 서비스를 함께 설치하고 활성화하려면:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
@@ -604,6 +652,12 @@ Windows PowerShell:
 
 ```powershell
 irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1 | iex
+```
+
+Windows PowerShell에서 상주 서비스를 함께 설치하고 활성화하려면:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
 설치가 끝나면 실행합니다(Linux/macOS는 `bin_dir`가 `PATH`에 포함되는지 확인하고, Windows는 `.cmd` shim을 만듭니다).
@@ -635,7 +689,7 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/doggy8088/TokenUsageIns
 - `static/`의 프런트엔드 자산
 - 모델 가격표 `pricing.csv`
 - `shell/` 디렉터리의 Status Line 및 서비스 스크립트
-- `scripts/` 디렉터리(`install.sh`, `install.ps1`, `get.sh`, `get.ps1` 포함)
+- `scripts/` 디렉터리(`install.sh`, `install.ps1`, `get.sh`, `get.ps1`, `run-service.ps1` 포함)
 - README, LICENSE 및 VERSION
 
 Linux 또는 macOS:
@@ -646,7 +700,7 @@ cd token-usage-insights-<tag>-<target>
 ./install.sh
 ```
 
-Linux에서 systemd 사용자 서비스를 설치하고 활성화하려면:
+Linux(systemd user service) 또는 macOS(launchd LaunchAgent)에서 상주 서비스를 설치하고 활성화하려면:
 
 ```bash
 ./install.sh --service
@@ -658,6 +712,12 @@ Windows:
 Expand-Archive token-usage-insights-<tag>-x86_64-pc-windows-msvc.zip
 cd token-usage-insights-<tag>-x86_64-pc-windows-msvc
 powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+Windows에서 백그라운드 상주 서비스를 설치하고 활성화하려면:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Service
 ```
 
 Windows 설치 위치 및 포트 사용자 지정:

--- a/README.ko.md
+++ b/README.ko.md
@@ -611,8 +611,29 @@ Windows PowerShell:
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# 실시간 로그 확인
-Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+# 실시간 로그 확인(실제 InstallDir 자동 감지)
+$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+if ($Task -and $Task.Actions) {
+    foreach ($Action in @($Task.Actions)) {
+        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            break
+        }
+    }
+} else {
+    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+    if (!(Test-Path $StartupShortcut)) {
+        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+    }
+    if (Test-Path $StartupShortcut) {
+        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        }
+    }
+}
+Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
 # 서비스 다시 시작(작업 스케줄러 및 시작프로그램 모드 자동 호환)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue

--- a/README.ko.md
+++ b/README.ko.md
@@ -616,8 +616,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
-        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
         }
     }
@@ -630,8 +631,9 @@ if (-not $InstallDir) {
     if (Test-Path $StartupShortcut) {
         $WshShell = New-Object -ComObject WScript.Shell
         $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
         } elseif ($Shortcut.WorkingDirectory) {
             $InstallDir = $Shortcut.WorkingDirectory
         }

--- a/README.ko.md
+++ b/README.ko.md
@@ -616,6 +616,7 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 
 # 서비스 다시 시작(작업 스케줄러 및 시작프로그램 모드 자동 호환)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
 if (!(Test-Path $StartupShortcut)) {
@@ -629,6 +630,7 @@ if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContin
 
 # 서비스 중지
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 상주 서비스 등록 해제
@@ -638,6 +640,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -607,16 +607,21 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell:
 
 ```powershell
-# 서비스 상태 확인
-Get-ScheduledTask -TaskName "TokenUsageInsights"
+# 서비스 상태 확인(작업 스케줄러 또는 백그라운드 프로세스)
+Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # 실시간 로그 확인
 Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
 
-# 서비스 다시 시작
+# 서비스 다시 시작(작업 스케줄러 및 시작프로그램 모드 자동 호환)
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-Start-ScheduledTask -TaskName "TokenUsageInsights"
+if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName "TokenUsageInsights"
+} else {
+    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+}
 
 # 서비스 중지
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
@@ -629,6 +634,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 
 * * *

--- a/README.md
+++ b/README.md
@@ -628,15 +628,18 @@ Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # 檢視即時日誌（自動取得實際 InstallDir）
 $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$ResolvedInstallDir = $false
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
             break
         }
     }
-} else {
+}
+if (-not $ResolvedInstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
@@ -645,6 +648,7 @@ if ($Task -and $Task.Actions) {
         $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -626,8 +626,29 @@ Windows PowerShell 可使用：
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# 檢視即時日誌
-Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+# 檢視即時日誌（自動取得實際 InstallDir）
+$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+if ($Task -and $Task.Actions) {
+    foreach ($Action in @($Task.Actions)) {
+        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            break
+        }
+    }
+} else {
+    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+    if (!(Test-Path $StartupShortcut)) {
+        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+    }
+    if (Test-Path $StartupShortcut) {
+        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        }
+    }
+}
+Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
 # 重啟服務（自動相容工作排程器與啟動資料夾模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue

--- a/README.md
+++ b/README.md
@@ -638,7 +638,12 @@ Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 解除安裝常駐服務
-Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 ```
 
 * * *

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
-這會透過 Windows 工作排程器（Task Scheduler）註冊 `TokenUsageInsights` 背景工作並立即啟動；使用者每次登入時均會自動於背景執行，標準輸出與錯誤日誌位於 `%LOCALAPPDATA%\TokenUsageInsights\logs\`。
+這會透過 Windows 工作排程器（Task Scheduler）註冊專屬於目前使用者的 `TokenUsageInsights_<username>` 背景工作並立即啟動；使用者每次登入時均會自動於背景執行，標準輸出與錯誤日誌位於安裝目錄下的 `logs\`（預設為 `%LOCALAPPDATA%\TokenUsageInsights\logs\`）。
 
 ### 管理服務
 
@@ -622,71 +622,82 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell 可使用：
 
 ```powershell
-# 檢視服務狀態（工作排程器或背景行程）
-Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
-
-# 檢視即時日誌（支援自訂 -InstallDir）
+# 解析安裝目錄（預設為 %LOCALAPPDATA%\TokenUsageInsights，或由已註冊排程/捷徑動態解析）
+$TaskName = if ($env:USERNAME) { "TokenUsageInsights_$env:USERNAME" } else { "TokenUsageInsights" }
 $InstallDir = $null
-$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+$Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $Task) {
+    $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+}
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
             $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
             $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
+        } elseif ($Action.WorkingDirectory) {
+            $InstallDir = $Action.WorkingDirectory
+            break
         }
     }
 }
-if (-not $InstallDir) {
-    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-    if (!(Test-Path $StartupShortcut)) {
-        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-    }
-    if (Test-Path $StartupShortcut) {
-        $WshShell = New-Object -ComObject WScript.Shell
-        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
-            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
-        } elseif ($Shortcut.WorkingDirectory) {
-            $InstallDir = $Shortcut.WorkingDirectory
-        }
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
+    if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+        $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+        $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
+    } elseif ($Shortcut.WorkingDirectory) {
+        $InstallDir = $Shortcut.WorkingDirectory
     }
 }
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+
+# 檢視服務狀態（工作排程器或背景行程）
+Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | Select-Object ProcessId, Name, CommandLine
+
+# 檢視即時日誌
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
-# 重啟服務（自動相容工作排程器與啟動資料夾模式）
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-}
-if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
-    Start-ScheduledTask -TaskName "TokenUsageInsights"
+# 重啟服務（僅限此安裝目錄，自動相容工作排程器與啟動資料夾模式）
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName $TaskName
 } elseif (Test-Path $StartupShortcut) {
     Start-Process $StartupShortcut
 }
 
-# 停止服務
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+# 停止服務（僅限此安裝目錄）
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 解除安裝常駐服務
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+if (Test-Path $StartupShortcut) {
+    Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
-Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 
 * * *

--- a/README.md
+++ b/README.md
@@ -626,31 +626,34 @@ Windows PowerShell 可使用：
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# 檢視即時日誌（自動取得實際 InstallDir）
-$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
-$ResolvedInstallDir = $false
+# 檢視即時日誌（支援自訂 -InstallDir）
+$InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
             break
         }
     }
 }
-if (-not $ResolvedInstallDir) {
+if (-not $InstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
     }
     if (Test-Path $StartupShortcut) {
-        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        $WshShell = New-Object -ComObject WScript.Shell
+        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
+        } elseif ($Shortcut.WorkingDirectory) {
+            $InstallDir = $Shortcut.WorkingDirectory
         }
     }
+}
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 

--- a/README.md
+++ b/README.md
@@ -628,6 +628,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if (-not $Task) {
     $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+    if ($Task) {
+        $TaskName = "TokenUsageInsights"
+    }
 }
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {

--- a/README.md
+++ b/README.md
@@ -592,7 +592,17 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 
 這會將 `com.tokenusageinsights.plist` 安裝到 `~/Library/LaunchAgents/` 並立即載入；標準輸出與錯誤日誌位於 `~/Library/Logs/`。
 
+### Windows：一行安裝並啟用背景常駐服務（工作排程器）
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+```
+
+這會透過 Windows 工作排程器（Task Scheduler）註冊 `TokenUsageInsights` 背景工作並立即啟動；使用者每次登入時均會自動於背景執行，標準輸出與錯誤日誌位於 `%LOCALAPPDATA%\TokenUsageInsights\logs\`。
+
 ### 管理服務
+
+Linux 可使用：
 
 ```bash
 systemctl --user status token-usage-insights.service
@@ -607,6 +617,28 @@ macOS 可使用：
 launchctl print gui/$(id -u)/com.tokenusageinsights
 launchctl kickstart -k gui/$(id -u)/com.tokenusageinsights
 launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.plist
+```
+
+Windows PowerShell 可使用：
+
+```powershell
+# 檢視服務狀態
+Get-ScheduledTask -TaskName "TokenUsageInsights"
+
+# 檢視即時日誌
+Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+
+# 重啟服務
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-ScheduledTask -TaskName "TokenUsageInsights"
+
+# 停止服務
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+
+# 解除安裝常駐服務
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
 ```
 
 * * *
@@ -647,6 +679,12 @@ Windows PowerShell：
 irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1 | iex
 ```
 
+Windows PowerShell 如需同時安裝並啟用常駐服務：
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+```
+
 安裝完成後即可執行（Linux/macOS 需確認 `bin_dir` 已加入 `PATH`；Windows 會建立 `.cmd` shim）：
 
 ```bash
@@ -676,7 +714,7 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/doggy8088/TokenUsageIns
 - `static/` 前端資產
 - `pricing.csv` 模型費用表
 - `shell/` 目錄下的 Status Line 與服務腳本
-- `scripts/` 目錄（含 `install.sh`、`install.ps1`、`get.sh`、`get.ps1`）
+- `scripts/` 目錄（含 `install.sh`、`install.ps1`、`get.sh`、`get.ps1`、`run-service.ps1`）
 - README、LICENSE 與 VERSION
 
 Linux 或 macOS：
@@ -699,6 +737,12 @@ Windows：
 Expand-Archive token-usage-insights-<tag>-x86_64-pc-windows-msvc.zip
 cd token-usage-insights-<tag>-x86_64-pc-windows-msvc
 powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+Windows 如需安裝並啟用背景常駐服務：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Service
 ```
 
 自訂 Windows 安裝位置與埠號：

--- a/README.md
+++ b/README.md
@@ -632,10 +632,14 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 # 重啟服務（自動相容工作排程器與啟動資料夾模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
 if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName "TokenUsageInsights"
-} else {
-    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+} elseif (Test-Path $StartupShortcut) {
+    Start-Process $StartupShortcut
 }
 
 # 停止服務

--- a/README.md
+++ b/README.md
@@ -661,12 +661,14 @@ if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+$TargetExe = "$InstallDir\token-usage-insights.exe".ToLowerInvariant().Replace('/', '\')
+$EscapedDir = [regex]::Escape($InstallDir)
 
 # 檢視服務狀態（工作排程器或背景行程）
 Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | Select-Object ProcessId, Name, CommandLine
 
 # 檢視即時日誌
@@ -675,8 +677,8 @@ Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50
 # 重啟服務（僅限此安裝目錄，自動相容工作排程器與啟動資料夾模式）
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName $TaskName
@@ -687,8 +689,8 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
 # 停止服務（僅限此安裝目錄）
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 解除安裝常駐服務
@@ -698,8 +700,8 @@ if (Test-Path $StartupShortcut) {
     Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 

--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 
 # 重啟服務（自動相容工作排程器與啟動資料夾模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
 if (!(Test-Path $StartupShortcut)) {
@@ -644,6 +645,7 @@ if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContin
 
 # 停止服務
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 解除安裝常駐服務
@@ -653,6 +655,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 

--- a/README.md
+++ b/README.md
@@ -622,16 +622,21 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell 可使用：
 
 ```powershell
-# 檢視服務狀態
-Get-ScheduledTask -TaskName "TokenUsageInsights"
+# 檢視服務狀態（工作排程器或背景行程）
+Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # 檢視即時日誌
 Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
 
-# 重啟服務
+# 重啟服務（自動相容工作排程器與啟動資料夾模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-Start-ScheduledTask -TaskName "TokenUsageInsights"
+if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName "TokenUsageInsights"
+} else {
+    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+}
 
 # 停止服務
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
@@ -644,6 +649,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 
 * * *

--- a/README.md
+++ b/README.md
@@ -631,8 +631,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
-        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
         }
     }
@@ -645,8 +646,9 @@ if (-not $InstallDir) {
     if (Test-Path $StartupShortcut) {
         $WshShell = New-Object -ComObject WScript.Shell
         $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
         } elseif ($Shortcut.WorkingDirectory) {
             $InstallDir = $Shortcut.WorkingDirectory
         }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -613,6 +613,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if (-not $Task) {
     $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+    if ($Task) {
+        $TaskName = "TokenUsageInsights"
+    }
 }
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -611,8 +611,29 @@ Windows PowerShell 可使用：
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# 查看实时日志
-Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+# 查看实时日志（自动获取实际 InstallDir）
+$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+if ($Task -and $Task.Actions) {
+    foreach ($Action in @($Task.Actions)) {
+        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            break
+        }
+    }
+} else {
+    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+    if (!(Test-Path $StartupShortcut)) {
+        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+    }
+    if (Test-Path $StartupShortcut) {
+        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        }
+    }
+}
+Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
 # 重启服务（自动兼容任务计划程序与启动文件夹模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -623,7 +623,12 @@ Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 卸载常驻服务
-Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 ```
 
 * * *

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -583,7 +583,7 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
-这会通过 Windows 任务计划程序（Task Scheduler）注册 `TokenUsageInsights` 计划任务并立即启动；用户每次登录时均会自动在后台运行，标准输出与错误日志位于 `%LOCALAPPDATA%\TokenUsageInsights\logs\`。
+这会通过 Windows 任务计划程序（Task Scheduler）注册专属于当前用户的 `TokenUsageInsights_<username>` 计划任务并立即启动；用户每次登录时均会自动在后台运行，标准输出与错误日志位于安装目录下的 `logs\`（默认为 `%LOCALAPPDATA%\TokenUsageInsights\logs\`）。
 
 ### 管理服务
 
@@ -607,71 +607,82 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell 可使用：
 
 ```powershell
-# 查看服务状态（任务计划程序或后台进程）
-Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
-
-# 查看实时日志（支持自定义 -InstallDir）
+# 解析安装目录（默认为 %LOCALAPPDATA%\TokenUsageInsights，或由已注册计划任务/快捷方式动态解析）
+$TaskName = if ($env:USERNAME) { "TokenUsageInsights_$env:USERNAME" } else { "TokenUsageInsights" }
 $InstallDir = $null
-$Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+$Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $Task) {
+    $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+}
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
             $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
             $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
+        } elseif ($Action.WorkingDirectory) {
+            $InstallDir = $Action.WorkingDirectory
+            break
         }
     }
 }
-if (-not $InstallDir) {
-    $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-    if (!(Test-Path $StartupShortcut)) {
-        $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-    }
-    if (Test-Path $StartupShortcut) {
-        $WshShell = New-Object -ComObject WScript.Shell
-        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
-            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
-        } elseif ($Shortcut.WorkingDirectory) {
-            $InstallDir = $Shortcut.WorkingDirectory
-        }
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
+if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
+    if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+        $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+        $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
+    } elseif ($Shortcut.WorkingDirectory) {
+        $InstallDir = $Shortcut.WorkingDirectory
     }
 }
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+
+# 查看服务状态（任务计划程序或后台进程）
+Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | Select-Object ProcessId, Name, CommandLine
+
+# 查看实时日志
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 
-# 重启服务（自动兼容任务计划程序与启动文件夹模式）
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
-}
-if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
-    Start-ScheduledTask -TaskName "TokenUsageInsights"
+# 重启服务（仅限此安装目录，自动兼容任务计划程序与启动文件夹模式）
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName $TaskName
 } elseif (Test-Path $StartupShortcut) {
     Start-Process $StartupShortcut
 }
 
-# 停止服务
-Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+# 停止服务（仅限此安装目录）
+Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 卸载常驻服务
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
-$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
-if (!(Test-Path $StartupShortcut)) {
-    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+if (Test-Path $StartupShortcut) {
+    Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
-Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
-Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
+    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 
 * * *

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -616,6 +616,7 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 
 # 重启服务（自动兼容任务计划程序与启动文件夹模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
 if (!(Test-Path $StartupShortcut)) {
@@ -629,6 +630,7 @@ if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContin
 
 # 停止服务
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 
 # 卸载常驻服务
@@ -638,6 +640,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like "*run-service.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -611,31 +611,34 @@ Windows PowerShell 可使用：
 Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
-# 查看实时日志（自动获取实际 InstallDir）
-$InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
-$ResolvedInstallDir = $false
+# 查看实时日志（支持自定义 -InstallDir）
+$InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
             break
         }
     }
 }
-if (-not $ResolvedInstallDir) {
+if (-not $InstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
     }
     if (Test-Path $StartupShortcut) {
-        $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
+        $WshShell = New-Object -ComObject WScript.Shell
+        $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
-            $ResolvedInstallDir = $true
+        } elseif ($Shortcut.WorkingDirectory) {
+            $InstallDir = $Shortcut.WorkingDirectory
         }
     }
+}
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
 Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50 -Wait
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -613,15 +613,18 @@ Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # 查看实时日志（自动获取实际 InstallDir）
 $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
+$ResolvedInstallDir = $false
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
         if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
             break
         }
     }
-} else {
+}
+if (-not $ResolvedInstallDir) {
     $StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
     if (!(Test-Path $StartupShortcut)) {
         $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
@@ -630,6 +633,7 @@ if ($Task -and $Task.Actions) {
         $Shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($StartupShortcut)
         if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
             $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+            $ResolvedInstallDir = $true
         }
     }
 }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -646,12 +646,14 @@ if (-not $InstallDir -and (Test-Path $StartupShortcut)) {
 if (-not $InstallDir) {
     $InstallDir = Join-Path $env:LOCALAPPDATA "TokenUsageInsights"
 }
+$TargetExe = "$InstallDir\token-usage-insights.exe".ToLowerInvariant().Replace('/', '\')
+$EscapedDir = [regex]::Escape($InstallDir)
 
 # 查看服务状态（任务计划程序或后台进程）
 Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | Select-Object ProcessId, Name, CommandLine
 
 # 查看实时日志
@@ -660,8 +662,8 @@ Get-Content (Join-Path $InstallDir "logs\token-usage-insights.out.log") -Tail 50
 # 重启服务（仅限此安装目录，自动兼容任务计划程序与启动文件夹模式）
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName $TaskName
@@ -672,8 +674,8 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
 # 停止服务（仅限此安装目录）
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 # 卸载常驻服务
@@ -683,8 +685,8 @@ if (Test-Path $StartupShortcut) {
     Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
 }
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -like "*$InstallDir*") -or
-    ($_.ExecutablePath -and $_.ExecutablePath -like "$InstallDir*")
+    ($_.CommandLine -like "*run-service.ps1*" -and $_.CommandLine -match "(?i)[\s`"'\\]$EscapedDir([\\`"'\s]|$)") -or
+    ($_.ExecutablePath -and ($_.ExecutablePath.ToLowerInvariant().Replace('/', '\') -eq $TargetExe))
 } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -616,8 +616,9 @@ $InstallDir = $null
 $Task = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 if ($Task -and $Task.Actions) {
     foreach ($Action in @($Task.Actions)) {
-        if ($Action.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Action.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
             break
         }
     }
@@ -630,8 +631,9 @@ if (-not $InstallDir) {
     if (Test-Path $StartupShortcut) {
         $WshShell = New-Object -ComObject WScript.Shell
         $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-        if ($Shortcut.Arguments -match '(?i)-InstallDir\s+"([^"]+)"') {
-            $InstallDir = [Environment]::ExpandEnvironmentVariables($Matches[1])
+        if ($Shortcut.Arguments -match '(?i)-InstallDir(?:\s+|:)(?:"([^"]+)"|(\S+))') {
+            $DetectedInstallDir = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+            $InstallDir = [Environment]::ExpandEnvironmentVariables($DetectedInstallDir)
         } elseif ($Shortcut.WorkingDirectory) {
             $InstallDir = $Shortcut.WorkingDirectory
         }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -617,10 +617,14 @@ Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.
 # 重启服务（自动兼容任务计划程序与启动文件夹模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+$StartupShortcut = Join-Path ([Environment]::GetFolderPath('Startup')) "token-usage-insights.lnk"
+if (!(Test-Path $StartupShortcut)) {
+    $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+}
 if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
     Start-ScheduledTask -TaskName "TokenUsageInsights"
-} else {
-    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+} elseif (Test-Path $StartupShortcut) {
+    Start-Process $StartupShortcut
 }
 
 # 停止服务

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -607,16 +607,21 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.pli
 Windows PowerShell 可使用：
 
 ```powershell
-# 查看服务状态
-Get-ScheduledTask -TaskName "TokenUsageInsights"
+# 查看服务状态（任务计划程序或后台进程）
+Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue
 
 # 查看实时日志
 Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
 
-# 重启服务
+# 重启服务（自动兼容任务计划程序与启动文件夹模式）
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
 Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
-Start-ScheduledTask -TaskName "TokenUsageInsights"
+if (Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue) {
+    Start-ScheduledTask -TaskName "TokenUsageInsights"
+} else {
+    Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$env:LOCALAPPDATA\TokenUsageInsights\scripts\run-service.ps1`"" -WindowStyle Hidden
+}
 
 # 停止服务
 Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
@@ -629,6 +634,7 @@ if (!(Test-Path $StartupShortcut)) {
     $StartupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 }
 Remove-Item $StartupShortcut -Force -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
 ```
 
 * * *

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -569,13 +569,61 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/s
 
 这会下载安装版并立即启用 `token-usage-insights.service`，不需要自行构建或修改 systemd 文件。
 
+### macOS：一行安装并启用 launchd LaunchAgent
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
+```
+
+这会将 `com.tokenusageinsights.plist` 安装到 `~/Library/LaunchAgents/` 并立即加载；标准输出与错误日志位于 `~/Library/Logs/`。
+
+### Windows：一行安装并启用背景常驻服务（任务计划程序）
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+```
+
+这会通过 Windows 任务计划程序（Task Scheduler）注册 `TokenUsageInsights` 计划任务并立即启动；用户每次登录时均会自动在后台运行，标准输出与错误日志位于 `%LOCALAPPDATA%\TokenUsageInsights\logs\`。
+
 ### 管理服务
+
+Linux 可使用：
 
 ```bash
 systemctl --user status token-usage-insights.service
 journalctl --user -u token-usage-insights.service -n 50 -f
 systemctl --user restart token-usage-insights.service
 systemctl --user stop token-usage-insights.service
+```
+
+macOS 可使用：
+
+```bash
+launchctl print gui/$(id -u)/com.tokenusageinsights
+launchctl kickstart -k gui/$(id -u)/com.tokenusageinsights
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.tokenusageinsights.plist
+```
+
+Windows PowerShell 可使用：
+
+```powershell
+# 查看服务状态
+Get-ScheduledTask -TaskName "TokenUsageInsights"
+
+# 查看实时日志
+Get-Content "$env:LOCALAPPDATA\TokenUsageInsights\logs\token-usage-insights.out.log" -Tail 50 -Wait
+
+# 重启服务
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-ScheduledTask -TaskName "TokenUsageInsights"
+
+# 停止服务
+Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+Get-Process -Name "token-usage-insights" -ErrorAction SilentlyContinue | Stop-Process -Force
+
+# 卸载常驻服务
+Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false
 ```
 
 * * *
@@ -594,7 +642,7 @@ Linux / macOS：
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash
 ```
 
-Linux 如需同时安装并启用 systemd user service：
+Linux（systemd user service）或 macOS（launchd LaunchAgent）如需同时安装并启用常驻服务：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.sh | bash -s -- --service
@@ -604,6 +652,12 @@ Windows PowerShell：
 
 ```powershell
 irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1 | iex
+```
+
+Windows PowerShell 如需同时安装并启用常驻服务：
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
 ```
 
 安装完成后即可运行（Linux/macOS 需确认 `bin_dir` 已加入 `PATH`；Windows 会创建 `.cmd` shim）：
@@ -635,7 +689,7 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/doggy8088/TokenUsageIns
 - `static/` 前端资源
 - `pricing.csv` 模型费用表
 - `shell/` 目录下的 Status Line 与服务脚本
-- `scripts/` 目录（含 `install.sh`、`install.ps1`、`get.sh`、`get.ps1`）
+- `scripts/` 目录（含 `install.sh`、`install.ps1`、`get.sh`、`get.ps1`、`run-service.ps1`）
 - README、LICENSE 与 VERSION
 
 Linux 或 macOS：
@@ -646,7 +700,7 @@ cd token-usage-insights-<tag>-<target>
 ./install.sh
 ```
 
-Linux 如需安装并启用 systemd user service：
+Linux（systemd user service）或 macOS（launchd LaunchAgent）如需安装并启用常驻服务：
 
 ```bash
 ./install.sh --service
@@ -658,6 +712,12 @@ Windows：
 Expand-Archive token-usage-insights-<tag>-x86_64-pc-windows-msvc.zip
 cd token-usage-insights-<tag>-x86_64-pc-windows-msvc
 powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+Windows 如需安装并启用背景常驻服务：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Service
 ```
 
 自定义 Windows 安装位置与端口号：

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -23,7 +23,7 @@ param(
     [string]$InstallDir,
     [string]$BinDir,
     [string]$HostAddress,
-    [int]$Port = 3003,
+    [Nullable[int]]$Port = $null,
     [switch]$Service
 )
 
@@ -71,10 +71,11 @@ try {
         throw "install.ps1 not found in extracted release: $ExtractedDir"
     }
 
-    $InstallArgs = @{ Port = $Port }
+    $InstallArgs = @{}
     if ($InstallDir) { $InstallArgs["InstallDir"] = $InstallDir }
     if ($BinDir) { $InstallArgs["BinDir"] = $BinDir }
     if ($HostAddress) { $InstallArgs["HostAddress"] = $HostAddress }
+    if ($null -ne $Port) { $InstallArgs["Port"] = $Port }
     if ($Service) { $InstallArgs["Service"] = $true }
 
     Write-Host "Installing $Tag ..."

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -11,6 +11,9 @@
   irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1 | iex
 
 .EXAMPLE
+  & ([scriptblock]::Create((irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1))) -Service
+
+.EXAMPLE
   $script = irm https://raw.githubusercontent.com/doggy8088/TokenUsageInsights/main/scripts/get.ps1
   Invoke-Expression "& { $script } -InstallDir 'D:\Apps\Token Usage Insights' -Port 3010"
 #>
@@ -19,7 +22,9 @@ param(
     [string]$Version = "latest",
     [string]$InstallDir,
     [string]$BinDir,
-    [int]$Port = 3003
+    [string]$HostAddress,
+    [int]$Port = 3003,
+    [switch]$Service
 )
 
 $ErrorActionPreference = "Stop"
@@ -69,6 +74,8 @@ try {
     $InstallArgs = @{ Port = $Port }
     if ($InstallDir) { $InstallArgs["InstallDir"] = $InstallDir }
     if ($BinDir) { $InstallArgs["BinDir"] = $BinDir }
+    if ($HostAddress) { $InstallArgs["HostAddress"] = $HostAddress }
+    if ($Service) { $InstallArgs["Service"] = $true }
 
     Write-Host "Installing $Tag ..."
     & $InstallScript @InstallArgs

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,6 +88,17 @@ function Get-DashboardDisplayHost {
     return $HostAddress
 }
 
+function Get-ScheduledTaskLogonUser {
+    try {
+        $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        if ($identity -and $identity.Name) {
+            return $identity.Name
+        }
+    } catch {}
+
+    return $env:USERNAME
+}
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 if (Test-Path (Join-Path $ScriptDir "$AppName.exe")) {
     $ReleaseDir = $ScriptDir
@@ -160,12 +171,13 @@ exit /b %APP_EXIT_CODE%
         $StartupShortcut = Get-StartupShortcutPath
 
         try {
+            $taskLogonUser = Get-ScheduledTaskLogonUser
             $Action = New-ScheduledTaskAction `
                 -Execute "powershell.exe" `
                 -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
                 -WorkingDirectory $InstallDir
 
-            $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+            $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $taskLogonUser
 
             $Settings = New-ScheduledTaskSettingsSet `
                 -AllowStartIfOnBatteries `

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,6 +34,7 @@ function Stop-ExistingServiceInstance {
     $runnerScriptPath = [IO.Path]::GetFullPath((Join-Path $InstallDir "scripts\run-service.ps1"))
     $quotedRunnerFileArgument = "-File `"$runnerScriptPath`""
     $unquotedRunnerFileArgument = "-File $runnerScriptPath"
+    $appExecutablePath = [IO.Path]::GetFullPath((Join-Path $InstallDir "$ProcessName.exe"))
 
     try {
         Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
@@ -52,16 +53,26 @@ function Stop-ExistingServiceInstance {
         Stop-Process -Id $runnerHost.ProcessId -Force -ErrorAction SilentlyContinue
     }
 
-    $runningProcesses = @(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)
-    if ($runningProcesses.Count -gt 0) {
-        $runningProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+    $appProcesses = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        ($_.Name -eq "$ProcessName.exe") -and
+        (
+            ($_.ExecutablePath -and [IO.Path]::GetFullPath($_.ExecutablePath).Equals($appExecutablePath, [System.StringComparison]::OrdinalIgnoreCase)) -or
+            ($_.CommandLine -and (
+                $_.CommandLine.IndexOf("`"$appExecutablePath`"", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                $_.CommandLine.IndexOf($appExecutablePath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+            ))
+        )
+    })
+    $appProcessIds = @($appProcesses | ForEach-Object { $_.ProcessId })
+    foreach ($appProcess in $appProcesses) {
+        Stop-Process -Id $appProcess.ProcessId -Force -ErrorAction SilentlyContinue
     }
 
     $deadline = (Get-Date).AddSeconds(15)
     while (($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) -and (Get-Date) -lt $deadline) {
         Start-Sleep -Milliseconds 250
     }
-    while ((Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) -and (Get-Date) -lt $deadline) {
+    while (($appProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) -and (Get-Date) -lt $deadline) {
         Start-Sleep -Milliseconds 250
     }
 
@@ -69,7 +80,7 @@ function Stop-ExistingServiceInstance {
         throw "Failed to stop the existing background runner before reinstalling."
     }
 
-    if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
+    if ($appProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) {
         throw "Failed to stop the existing $ProcessName process before reinstalling."
     }
 }
@@ -184,6 +195,7 @@ exit /b %APP_EXIT_CODE%
 
         $StartupShortcut = Get-StartupShortcutPath
 
+        $taskRegistered = $false
         try {
             $taskLogonUser = Get-ScheduledTaskLogonUser
             $Action = New-ScheduledTaskAction `
@@ -211,15 +223,7 @@ exit /b %APP_EXIT_CODE%
                 -Settings $Settings `
                 -Description "Token 戰情室 Dashboard Background Service" `
                 -Force | Out-Null
-
-            Start-ScheduledTask -TaskName $TaskName
-            $registeredAsTask = $true
-
-            # Registration in Task Scheduler succeeded; remove any stale Startup folder shortcut
-            # to avoid dual launches on logon.
-            if ($PSCmdlet.ShouldProcess($StartupShortcut, "Remove stale Startup shortcut")) {
-                Remove-Item -Force -Path $StartupShortcut -ErrorAction SilentlyContinue
-            }
+            $taskRegistered = $true
         } catch {
             Write-Warning "Could not register scheduled task: $($_.Exception.Message). Falling back to Startup folder..."
             try {
@@ -238,6 +242,26 @@ exit /b %APP_EXIT_CODE%
             Start-Process -FilePath "powershell.exe" `
                 -ArgumentList "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
                 -WorkingDirectory $InstallDir -WindowStyle Hidden
+        }
+
+        if ($taskRegistered) {
+            $registeredAsTask = $true
+
+            try {
+                Start-ScheduledTask -TaskName $TaskName
+            } catch {
+                Write-Warning "Scheduled task registered, but automatic start failed: $($_.Exception.Message)"
+            }
+
+            # Registration in Task Scheduler succeeded; remove any stale Startup folder shortcut
+            # to avoid dual launches on logon.
+            if ($PSCmdlet.ShouldProcess($StartupShortcut, "Remove stale Startup shortcut")) {
+                try {
+                    Remove-Item -Force -Path $StartupShortcut -ErrorAction Stop
+                } catch {
+                    Write-Warning "Scheduled task registered, but removing the stale Startup shortcut failed: $($_.Exception.Message)"
+                }
+            }
         }
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -217,7 +217,9 @@ exit /b %APP_EXIT_CODE%
 
             # Registration in Task Scheduler succeeded; remove any stale Startup folder shortcut
             # to avoid dual launches on logon.
-            Remove-Item -Force -Path $StartupShortcut -ErrorAction SilentlyContinue
+            if ($PSCmdlet.ShouldProcess($StartupShortcut, "Remove stale Startup shortcut")) {
+                Remove-Item -Force -Path $StartupShortcut -ErrorAction SilentlyContinue
+            }
         } catch {
             Write-Warning "Could not register scheduled task: $($_.Exception.Message). Falling back to Startup folder..."
             try {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,9 @@ function Get-StartupShortcutPath {
     if (-not (Test-Path $startupFolder)) {
         $startupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
     }
+    if (-not (Test-Path $startupFolder)) {
+        New-Item -ItemType Directory -Force -Path $startupFolder | Out-Null
+    }
 
     Join-Path $startupFolder "$AppName.lnk"
 }
@@ -151,7 +154,13 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 
-    if ($Service) {
+    $existingTask = $false
+    try {
+        $existingTask = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
+    } catch {}
+    $existingShortcut = Test-Path (Get-StartupShortcutPath)
+
+    if ($Service -or $existingTask -or $existingShortcut -or (Get-Process -Name $AppName -ErrorAction SilentlyContinue)) {
         Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir
     }
 
@@ -265,6 +274,10 @@ exit /b %APP_EXIT_CODE%
                 }
             }
         }
+    } elseif ($existingTask) {
+        try {
+            Start-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        } catch {}
     }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -69,18 +69,20 @@ function Stop-ExistingServiceInstance {
     }
 
     $deadline = (Get-Date).AddSeconds(15)
-    while (($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) -and (Get-Date) -lt $deadline) {
+    while (@($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }).Count -gt 0 -and (Get-Date) -lt $deadline) {
         Start-Sleep -Milliseconds 250
     }
-    while (($appProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) -and (Get-Date) -lt $deadline) {
+    while (@($appProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }).Count -gt 0 -and (Get-Date) -lt $deadline) {
         Start-Sleep -Milliseconds 250
     }
 
-    if ($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) {
+    $remainingRunnerHostIds = @($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+    if ($remainingRunnerHostIds.Count -gt 0) {
         throw "Failed to stop the existing background runner before reinstalling."
     }
 
-    if ($appProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) {
+    $remainingAppProcessIds = @($appProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+    if ($remainingAppProcessIds.Count -gt 0) {
         throw "Failed to stop the existing $ProcessName process before reinstalling."
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -278,30 +278,34 @@ exit /b %APP_EXIT_CODE%
         try {
             Start-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
         } catch {}
+    } elseif ($existingShortcut -and (Test-Path $StartupShortcut)) {
+        try {
+            Start-Process $StartupShortcut
+        } catch {}
     }
-}
 
-Write-Host "Token 戰情室 installed."
-Write-Host ""
-Write-Host "Install directory:"
-Write-Host "  $InstallDir"
-Write-Host ""
-Write-Host "Executable shim:"
-Write-Host "  $(Join-Path $BinDir "$AppName.cmd")"
-Write-Host ""
-if ($Service) {
-    Write-Host "Background service:"
-    if ($registeredAsTask) {
-        Write-Host "  Registered task: $TaskName (Task Scheduler)"
-    } else {
-        Write-Host "  Registered in:   Startup folder"
-    }
-    Write-Host "  Logs directory:  $(Join-Path $InstallDir 'logs')"
+    Write-Host "Token 戰情室 installed."
     Write-Host ""
-    $displayHost = Get-DashboardDisplayHost -HostAddress $HostAddress
-    Write-Host "Dashboard URL:"
-    Write-Host "  http://${displayHost}:${Port}"
-} else {
-    Write-Host "Run:"
+    Write-Host "Install directory:"
+    Write-Host "  $InstallDir"
+    Write-Host ""
+    Write-Host "Executable shim:"
     Write-Host "  $(Join-Path $BinDir "$AppName.cmd")"
+    Write-Host ""
+    if ($Service) {
+        Write-Host "Background service:"
+        if ($registeredAsTask) {
+            Write-Host "  Registered task: $TaskName (Task Scheduler)"
+        } else {
+            Write-Host "  Registered in:   Startup folder"
+        }
+        Write-Host "  Logs directory:  $(Join-Path $InstallDir 'logs')"
+        Write-Host ""
+        $displayHost = Get-DashboardDisplayHost -HostAddress $HostAddress
+        Write-Host "Dashboard URL:"
+        Write-Host "  http://${displayHost}:${Port}"
+    } else {
+        Write-Host "Run:"
+        Write-Host "  $(Join-Path $BinDir "$AppName.cmd")"
+    }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,103 +16,138 @@ $InstallDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($
 $BinDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($BinDir))
 
 function Get-StartupShortcutPath {
-    param(
-        [switch]$EnsureDirectory
-    )
-
-    $startupFolder = [Environment]::GetFolderPath('Startup')
+    $startupFolder = $env:TOKEN_USAGE_INSIGHTS_STARTUP_DIR
+    if (-not $startupFolder) {
+        $startupFolder = [Environment]::GetFolderPath('Startup')
+    }
     if (-not (Test-Path $startupFolder)) {
         $startupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
     }
-    if ($EnsureDirectory -and (-not (Test-Path $startupFolder))) {
+    if (-not (Test-Path $startupFolder)) {
         New-Item -ItemType Directory -Force -Path $startupFolder | Out-Null
     }
 
     Join-Path $startupFolder "$AppName.lnk"
 }
 
+function Get-RunnerScriptPathFromArguments {
+    param([string]$Arguments)
+
+    if (-not $Arguments) {
+        return $null
+    }
+
+    $match = [regex]::Match($Arguments, '(?i)-(?:File|f)(?:\s+|:)(?:"([^"]+)"|(\S+))')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    $runnerScriptPath = $match.Groups[1].Value
+    if (-not $runnerScriptPath) {
+        $runnerScriptPath = $match.Groups[2].Value
+    }
+    if (-not $runnerScriptPath) {
+        return $null
+    }
+
+    $expandedRunnerScriptPath = [Environment]::ExpandEnvironmentVariables($runnerScriptPath)
+    return [IO.Path]::GetFullPath($expandedRunnerScriptPath)
+}
+
 function Stop-ExistingServiceInstance {
     param(
         [string]$TaskName,
         [string]$ProcessName,
-        [string]$InstallDir,
-        [string]$StartupShortcutPath
+        [string]$InstallDir
     )
 
-    $targetDirs = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    if ($InstallDir) {
-        $null = $targetDirs.Add([IO.Path]::GetFullPath($InstallDir))
-    }
+    $runnerScriptPath = [IO.Path]::GetFullPath((Join-Path $InstallDir "scripts\run-service.ps1"))
+    $runnerScriptPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $null = $runnerScriptPaths.Add($runnerScriptPath)
 
     try {
-        $existingTaskObj = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        if ($existingTaskObj -and $existingTaskObj.Actions) {
-            foreach ($act in $existingTaskObj.Actions) {
-                if ($act.WorkingDirectory) {
-                    $null = $targetDirs.Add([IO.Path]::GetFullPath($act.WorkingDirectory))
-                }
-                if ($act.Argument -and $act.Argument -match '-InstallDir\s+"?([^"]+?)(?:"|\s|$)') {
-                    $null = $targetDirs.Add([IO.Path]::GetFullPath($Matches[1]))
-                }
-                if ($act.Argument -and $act.Argument -match '-File\s+"?([^"]+?[\\/]run-service\.ps1)"?') {
-                    $scriptDir = Split-Path -Parent $Matches[1]
-                    $installParent = Split-Path -Parent $scriptDir
-                    if ($installParent) {
-                        $null = $targetDirs.Add([IO.Path]::GetFullPath($installParent))
-                    }
+        $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        if ($existingTask -and $existingTask.Actions) {
+            foreach ($action in @($existingTask.Actions)) {
+                $taskRunnerPath = Get-RunnerScriptPathFromArguments -Arguments $action.Arguments
+                if ($taskRunnerPath) {
+                    $null = $runnerScriptPaths.Add($taskRunnerPath)
                 }
             }
         }
     } catch {}
 
-    if ($StartupShortcutPath -and (Test-Path $StartupShortcutPath)) {
-        try {
-            $wsh = New-Object -ComObject WScript.Shell
-            $sc = $wsh.CreateShortcut($StartupShortcutPath)
-            if ($sc.WorkingDirectory) {
-                $null = $targetDirs.Add([IO.Path]::GetFullPath($sc.WorkingDirectory))
+    try {
+        $startupShortcutPath = Get-StartupShortcutPath
+        if (Test-Path $startupShortcutPath) {
+            $wshShell = New-Object -ComObject WScript.Shell
+            $startupShortcut = $wshShell.CreateShortcut($startupShortcutPath)
+            $shortcutRunnerPath = Get-RunnerScriptPathFromArguments -Arguments $startupShortcut.Arguments
+            if (-not $shortcutRunnerPath -and $startupShortcut.TargetPath -and $startupShortcut.TargetPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
+                $shortcutRunnerPath = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($startupShortcut.TargetPath))
             }
-            if ($sc.Arguments -and $sc.Arguments -match '-InstallDir\s+"?([^"]+?)(?:"|\s|$)') {
-                $null = $targetDirs.Add([IO.Path]::GetFullPath($Matches[1]))
+            if ($shortcutRunnerPath) {
+                $null = $runnerScriptPaths.Add($shortcutRunnerPath)
             }
-            if ($sc.Arguments -and $sc.Arguments -match '-File\s+"?([^"]+?[\\/]run-service\.ps1)"?') {
-                $scriptDir = Split-Path -Parent $Matches[1]
-                $installParent = Split-Path -Parent $scriptDir
-                if ($installParent) {
-                    $null = $targetDirs.Add([IO.Path]::GetFullPath($installParent))
-                }
-            }
-        } catch {}
+        }
+    } catch {}
+
+    $runnerFileArguments = @()
+    foreach ($knownRunnerScriptPath in $runnerScriptPaths) {
+        $runnerFileArguments += "-File `"$knownRunnerScriptPath`""
+        $runnerFileArguments += "-File $knownRunnerScriptPath"
+        $runnerFileArguments += "-File:`"$knownRunnerScriptPath`""
+        $runnerFileArguments += "-File:$knownRunnerScriptPath"
+        $runnerFileArguments += "-f `"$knownRunnerScriptPath`""
+        $runnerFileArguments += "-f $knownRunnerScriptPath"
+        $runnerFileArguments += "-f:`"$knownRunnerScriptPath`""
+        $runnerFileArguments += "-f:$knownRunnerScriptPath"
+        $runnerScriptPathWithBackslashes = $knownRunnerScriptPath.Replace('/', '\')
+        $runnerFileArguments += "-File `"$runnerScriptPathWithBackslashes`""
+        $runnerFileArguments += "-File $runnerScriptPathWithBackslashes"
+        $runnerFileArguments += "-File:`"$runnerScriptPathWithBackslashes`""
+        $runnerFileArguments += "-File:$runnerScriptPathWithBackslashes"
+        $runnerFileArguments += "-f `"$runnerScriptPathWithBackslashes`""
+        $runnerFileArguments += "-f $runnerScriptPathWithBackslashes"
+        $runnerFileArguments += "-f:`"$runnerScriptPathWithBackslashes`""
+        $runnerFileArguments += "-f:$runnerScriptPathWithBackslashes"
+    }
+
+    $appExecutablePaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $appExecutablePath = [IO.Path]::GetFullPath((Join-Path $InstallDir "$ProcessName.exe"))
+    $null = $appExecutablePaths.Add($appExecutablePath)
+    foreach ($knownRunnerScriptPath in $runnerScriptPaths) {
+        $runnerScriptDir = Split-Path -Parent $knownRunnerScriptPath
+        if (-not $runnerScriptDir) {
+            continue
+        }
+
+        $runnerInstallDir = Split-Path -Parent $runnerScriptDir
+        if (-not $runnerInstallDir) {
+            continue
+        }
+
+        $runnerExecutablePath = [IO.Path]::GetFullPath((Join-Path $runnerInstallDir "$ProcessName.exe"))
+        $null = $appExecutablePaths.Add($runnerExecutablePath)
     }
 
     try {
         Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     } catch {}
 
-    $runnerScriptPaths = @($targetDirs | ForEach-Object { [IO.Path]::GetFullPath((Join-Path $_ "scripts\run-service.ps1")) })
-    $appExecutablePaths = @($targetDirs | ForEach-Object { [IO.Path]::GetFullPath((Join-Path $_ "$ProcessName.exe")) })
-
     $runnerHosts = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-        $cmd = $_.CommandLine
-        if (($_.Name -in @("powershell.exe", "pwsh.exe")) -and $cmd) {
-            $cmdNorm = $cmd.Replace('\', '/')
-            $match = $false
-            foreach ($scriptPath in $runnerScriptPaths) {
-                $scriptPathNorm = $scriptPath.Replace('\', '/')
-                $quoted = "-File `"$scriptPathNorm`""
-                $unquoted = "-File $scriptPathNorm"
-                if (
-                    $cmdNorm.IndexOf($quoted, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
-                    $cmdNorm.IndexOf($unquoted, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
-                ) {
-                    $match = $true
+        ($_.Name -in @("powershell.exe", "pwsh.exe")) -and
+        $_.CommandLine -and
+        $(
+            $matchesRunnerArgument = $false
+            foreach ($runnerFileArgument in $runnerFileArguments) {
+                if ($_.CommandLine.IndexOf($runnerFileArgument, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                    $matchesRunnerArgument = $true
                     break
                 }
             }
-            $match
-        } else {
-            $false
-        }
+            $matchesRunnerArgument
+        )
     })
     $runnerHostIds = @($runnerHosts | ForEach-Object { $_.ProcessId })
     foreach ($runnerHost in $runnerHosts) {
@@ -120,29 +155,24 @@ function Stop-ExistingServiceInstance {
     }
 
     $appProcesses = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-        if ($_.Name -eq "$ProcessName.exe") {
-            $exePath = $_.ExecutablePath
-            $cmd = $_.CommandLine
-            $exePathNorm = if ($exePath) { [IO.Path]::GetFullPath($exePath).Replace('\', '/') } else { $null }
-            $cmdNorm = if ($cmd) { $cmd.Replace('\', '/') } else { $null }
-            $match = $false
-            foreach ($exeTarget in $appExecutablePaths) {
-                $exeTargetNorm = $exeTarget.Replace('\', '/')
+        ($_.Name -eq "$ProcessName.exe") -and
+        $(
+            $matchesExecutablePath = $false
+            foreach ($knownExecutablePath in $appExecutablePaths) {
                 if (
-                    ($exePathNorm -and $exePathNorm.Equals($exeTargetNorm, [System.StringComparison]::OrdinalIgnoreCase)) -or
-                    ($cmdNorm -and (
-                        $cmdNorm.IndexOf("`"$exeTargetNorm`"", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
-                        $cmdNorm.IndexOf($exeTargetNorm, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+                    ($_.ExecutablePath -and $_.ExecutablePath.Replace('/', '\').Equals($knownExecutablePath.Replace('/', '\'), [System.StringComparison]::OrdinalIgnoreCase)) -or
+                    ($_.CommandLine -and (
+                        $_.CommandLine.IndexOf("`"$knownExecutablePath`"", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                        $_.CommandLine.IndexOf($knownExecutablePath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                        $_.CommandLine.IndexOf($knownExecutablePath.Replace('/', '\'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0
                     ))
                 ) {
-                    $match = $true
+                    $matchesExecutablePath = $true
                     break
                 }
             }
-            $match
-        } else {
-            $false
-        }
+            $matchesExecutablePath
+        )
     })
     $appProcessIds = @($appProcesses | ForEach-Object { $_.ProcessId })
     foreach ($appProcess in $appProcesses) {
@@ -207,6 +237,25 @@ function Get-ScheduledTaskLogonUser {
     return $null
 }
 
+function Set-StartupShortcutForRunner {
+    param(
+        [string]$ShortcutPath,
+        [string]$RunnerScript,
+        [string]$InstallDir,
+        [string]$HostAddress,
+        [int]$Port
+    )
+
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Shortcut = $WshShell.CreateShortcut($ShortcutPath)
+    $Shortcut.TargetPath = "powershell.exe"
+    $Shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port"
+    $Shortcut.WorkingDirectory = $InstallDir
+    $Shortcut.WindowStyle = 7
+    $Shortcut.Description = "Token 戰情室 Dashboard Background Service"
+    $Shortcut.Save()
+}
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 if (Test-Path (Join-Path $ScriptDir "$AppName.exe")) {
     $ReleaseDir = $ScriptDir
@@ -236,11 +285,15 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     try {
         $existingTask = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
     } catch {}
-    $StartupShortcut = Get-StartupShortcutPath
-    $existingShortcut = Test-Path $StartupShortcut
+    $hadScheduledTaskBeforeStop = $existingTask
+    $hadStartupShortcutBeforeStop = $false
+    $startupShortcutPath = Get-StartupShortcutPath
+    $existingShortcut = Test-Path $startupShortcutPath
+    $hadStartupShortcutBeforeStop = $existingShortcut
+    $hadPersistentServiceRegistration = $hadScheduledTaskBeforeStop -or $existingShortcut
 
-    if ($Service -or $existingTask -or $existingShortcut -or (Get-Process -Name $AppName -ErrorAction SilentlyContinue)) {
-        Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir -StartupShortcutPath $StartupShortcut
+    if ($Service -or $hadPersistentServiceRegistration) {
+        Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir
     }
 
     Copy-Item -Force $BinarySrc (Join-Path $InstallDir "$AppName.exe")
@@ -318,15 +371,12 @@ exit /b %APP_EXIT_CODE%
                 Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
             } catch {}
 
-            $StartupShortcut = Get-StartupShortcutPath -EnsureDirectory
-            $WshShell = New-Object -ComObject WScript.Shell
-            $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
-            $Shortcut.TargetPath = "powershell.exe"
-            $Shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port"
-            $Shortcut.WorkingDirectory = $InstallDir
-            $Shortcut.WindowStyle = 7
-            $Shortcut.Description = "Token 戰情室 Dashboard Background Service"
-            $Shortcut.Save()
+            Set-StartupShortcutForRunner `
+                -ShortcutPath $startupShortcutPath `
+                -RunnerScript $RunnerScript `
+                -InstallDir $InstallDir `
+                -HostAddress $HostAddress `
+                -Port $Port
 
             Start-Process -FilePath "powershell.exe" `
                 -ArgumentList "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
@@ -344,22 +394,34 @@ exit /b %APP_EXIT_CODE%
 
             # Registration in Task Scheduler succeeded; remove any stale Startup folder shortcut
             # to avoid dual launches on logon.
-            if ($PSCmdlet.ShouldProcess($StartupShortcut, "Remove stale Startup shortcut")) {
+            if ($PSCmdlet.ShouldProcess($startupShortcutPath, "Remove stale Startup shortcut")) {
                 try {
-                    Remove-Item -Force -Path $StartupShortcut -ErrorAction Stop
+                    Remove-Item -Force -Path $startupShortcutPath -ErrorAction Stop
                 } catch {
                     Write-Warning "Scheduled task registered, but removing the stale Startup shortcut failed: $($_.Exception.Message)"
                 }
             }
         }
-    } elseif ($existingTask) {
-        try {
-            Start-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        } catch {}
-    } elseif ($existingShortcut -and (Test-Path $StartupShortcut)) {
-        try {
-            Start-Process $StartupShortcut
-        } catch {}
+    } elseif ($hadPersistentServiceRegistration) {
+        $runnerScript = Join-Path (Join-Path $InstallDir "scripts") "run-service.ps1"
+        $startupShortcutReady = Test-Path $startupShortcutPath
+        if ($hadStartupShortcutBeforeStop -and (Test-Path $runnerScript) -and -not $startupShortcutReady) {
+            try {
+                Set-StartupShortcutForRunner `
+                    -ShortcutPath $startupShortcutPath `
+                    -RunnerScript $runnerScript `
+                    -InstallDir $InstallDir `
+                    -HostAddress $HostAddress `
+                    -Port $Port
+                $startupShortcutReady = Test-Path $startupShortcutPath
+            } catch {}
+        }
+
+        if ($hadStartupShortcutBeforeStop -and $startupShortcutReady) {
+            try {
+                Start-Process $startupShortcutPath
+            } catch {}
+        }
     }
 
     Write-Host "Token 戰情室 installed."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,11 +16,15 @@ $InstallDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($
 $BinDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($BinDir))
 
 function Get-StartupShortcutPath {
+    param(
+        [switch]$EnsureDirectory
+    )
+
     $startupFolder = [Environment]::GetFolderPath('Startup')
     if (-not (Test-Path $startupFolder)) {
         $startupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
     }
-    if (-not (Test-Path $startupFolder)) {
+    if ($EnsureDirectory -and (-not (Test-Path $startupFolder))) {
         New-Item -ItemType Directory -Force -Path $startupFolder | Out-Null
     }
 
@@ -31,25 +35,84 @@ function Stop-ExistingServiceInstance {
     param(
         [string]$TaskName,
         [string]$ProcessName,
-        [string]$InstallDir
+        [string]$InstallDir,
+        [string]$StartupShortcutPath
     )
 
-    $runnerScriptPath = [IO.Path]::GetFullPath((Join-Path $InstallDir "scripts\run-service.ps1"))
-    $quotedRunnerFileArgument = "-File `"$runnerScriptPath`""
-    $unquotedRunnerFileArgument = "-File $runnerScriptPath"
-    $appExecutablePath = [IO.Path]::GetFullPath((Join-Path $InstallDir "$ProcessName.exe"))
+    $targetDirs = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    if ($InstallDir) {
+        $null = $targetDirs.Add([IO.Path]::GetFullPath($InstallDir))
+    }
+
+    try {
+        $existingTaskObj = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        if ($existingTaskObj -and $existingTaskObj.Actions) {
+            foreach ($act in $existingTaskObj.Actions) {
+                if ($act.WorkingDirectory) {
+                    $null = $targetDirs.Add([IO.Path]::GetFullPath($act.WorkingDirectory))
+                }
+                if ($act.Argument -and $act.Argument -match '-InstallDir\s+"?([^"]+?)(?:"|\s|$)') {
+                    $null = $targetDirs.Add([IO.Path]::GetFullPath($Matches[1]))
+                }
+                if ($act.Argument -and $act.Argument -match '-File\s+"?([^"]+?[\\/]run-service\.ps1)"?') {
+                    $scriptDir = Split-Path -Parent $Matches[1]
+                    $installParent = Split-Path -Parent $scriptDir
+                    if ($installParent) {
+                        $null = $targetDirs.Add([IO.Path]::GetFullPath($installParent))
+                    }
+                }
+            }
+        }
+    } catch {}
+
+    if ($StartupShortcutPath -and (Test-Path $StartupShortcutPath)) {
+        try {
+            $wsh = New-Object -ComObject WScript.Shell
+            $sc = $wsh.CreateShortcut($StartupShortcutPath)
+            if ($sc.WorkingDirectory) {
+                $null = $targetDirs.Add([IO.Path]::GetFullPath($sc.WorkingDirectory))
+            }
+            if ($sc.Arguments -and $sc.Arguments -match '-InstallDir\s+"?([^"]+?)(?:"|\s|$)') {
+                $null = $targetDirs.Add([IO.Path]::GetFullPath($Matches[1]))
+            }
+            if ($sc.Arguments -and $sc.Arguments -match '-File\s+"?([^"]+?[\\/]run-service\.ps1)"?') {
+                $scriptDir = Split-Path -Parent $Matches[1]
+                $installParent = Split-Path -Parent $scriptDir
+                if ($installParent) {
+                    $null = $targetDirs.Add([IO.Path]::GetFullPath($installParent))
+                }
+            }
+        } catch {}
+    }
 
     try {
         Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     } catch {}
 
+    $runnerScriptPaths = @($targetDirs | ForEach-Object { [IO.Path]::GetFullPath((Join-Path $_ "scripts\run-service.ps1")) })
+    $appExecutablePaths = @($targetDirs | ForEach-Object { [IO.Path]::GetFullPath((Join-Path $_ "$ProcessName.exe")) })
+
     $runnerHosts = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-        ($_.Name -in @("powershell.exe", "pwsh.exe")) -and
-        $_.CommandLine -and
-        (
-            $_.CommandLine.IndexOf($quotedRunnerFileArgument, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
-            $_.CommandLine.IndexOf($unquotedRunnerFileArgument, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
-        )
+        $cmd = $_.CommandLine
+        if (($_.Name -in @("powershell.exe", "pwsh.exe")) -and $cmd) {
+            $cmdNorm = $cmd.Replace('\', '/')
+            $match = $false
+            foreach ($scriptPath in $runnerScriptPaths) {
+                $scriptPathNorm = $scriptPath.Replace('\', '/')
+                $quoted = "-File `"$scriptPathNorm`""
+                $unquoted = "-File $scriptPathNorm"
+                if (
+                    $cmdNorm.IndexOf($quoted, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                    $cmdNorm.IndexOf($unquoted, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+                ) {
+                    $match = $true
+                    break
+                }
+            }
+            $match
+        } else {
+            $false
+        }
     })
     $runnerHostIds = @($runnerHosts | ForEach-Object { $_.ProcessId })
     foreach ($runnerHost in $runnerHosts) {
@@ -57,14 +120,29 @@ function Stop-ExistingServiceInstance {
     }
 
     $appProcesses = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-        ($_.Name -eq "$ProcessName.exe") -and
-        (
-            ($_.ExecutablePath -and [IO.Path]::GetFullPath($_.ExecutablePath).Equals($appExecutablePath, [System.StringComparison]::OrdinalIgnoreCase)) -or
-            ($_.CommandLine -and (
-                $_.CommandLine.IndexOf("`"$appExecutablePath`"", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
-                $_.CommandLine.IndexOf($appExecutablePath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
-            ))
-        )
+        if ($_.Name -eq "$ProcessName.exe") {
+            $exePath = $_.ExecutablePath
+            $cmd = $_.CommandLine
+            $exePathNorm = if ($exePath) { [IO.Path]::GetFullPath($exePath).Replace('\', '/') } else { $null }
+            $cmdNorm = if ($cmd) { $cmd.Replace('\', '/') } else { $null }
+            $match = $false
+            foreach ($exeTarget in $appExecutablePaths) {
+                $exeTargetNorm = $exeTarget.Replace('\', '/')
+                if (
+                    ($exePathNorm -and $exePathNorm.Equals($exeTargetNorm, [System.StringComparison]::OrdinalIgnoreCase)) -or
+                    ($cmdNorm -and (
+                        $cmdNorm.IndexOf("`"$exeTargetNorm`"", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                        $cmdNorm.IndexOf($exeTargetNorm, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+                    ))
+                ) {
+                    $match = $true
+                    break
+                }
+            }
+            $match
+        } else {
+            $false
+        }
     })
     $appProcessIds = @($appProcesses | ForEach-Object { $_.ProcessId })
     foreach ($appProcess in $appProcesses) {
@@ -158,10 +236,11 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     try {
         $existingTask = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
     } catch {}
-    $existingShortcut = Test-Path (Get-StartupShortcutPath)
+    $StartupShortcut = Get-StartupShortcutPath
+    $existingShortcut = Test-Path $StartupShortcut
 
     if ($Service -or $existingTask -or $existingShortcut -or (Get-Process -Name $AppName -ErrorAction SilentlyContinue)) {
-        Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir
+        Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir -StartupShortcutPath $StartupShortcut
     }
 
     Copy-Item -Force $BinarySrc (Join-Path $InstallDir "$AppName.exe")
@@ -204,8 +283,6 @@ exit /b %APP_EXIT_CODE%
             throw "Missing background service runner script: $RunnerScript"
         }
 
-        $StartupShortcut = Get-StartupShortcutPath
-
         $taskRegistered = $false
         try {
             $taskLogonUser = Get-ScheduledTaskLogonUser
@@ -241,6 +318,7 @@ exit /b %APP_EXIT_CODE%
                 Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
             } catch {}
 
+            $StartupShortcut = Get-StartupShortcutPath -EnsureDirectory
             $WshShell = New-Object -ComObject WScript.Shell
             $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
             $Shortcut.TargetPath = "powershell.exe"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,6 +15,75 @@ $AppName = "token-usage-insights"
 $InstallDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($InstallDir))
 $BinDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($BinDir))
 
+function Get-StartupShortcutPath {
+    $startupFolder = [Environment]::GetFolderPath('Startup')
+    if (-not (Test-Path $startupFolder)) {
+        $startupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
+    }
+
+    Join-Path $startupFolder "$AppName.lnk"
+}
+
+function Stop-ExistingServiceInstance {
+    param(
+        [string]$TaskName,
+        [string]$ProcessName,
+        [string]$InstallDir
+    )
+
+    try {
+        Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    } catch {}
+
+    $runnerHosts = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        ($_.Name -in @("powershell.exe", "pwsh.exe")) -and
+        $_.CommandLine -and
+        $_.CommandLine.IndexOf("run-service.ps1", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+        $_.CommandLine.IndexOf($InstallDir, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    })
+    $runnerHostIds = @($runnerHosts | ForEach-Object { $_.ProcessId })
+    foreach ($runnerHost in $runnerHosts) {
+        Stop-Process -Id $runnerHost.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+
+    $runningProcesses = @(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)
+    if ($runningProcesses.Count -gt 0) {
+        $runningProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+
+    $deadline = (Get-Date).AddSeconds(15)
+    while (($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) -and (Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 250
+    }
+    while ((Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) -and (Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 250
+    }
+
+    if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
+        throw "Failed to stop the existing $ProcessName process before reinstalling."
+    }
+}
+
+function Get-DashboardDisplayHost {
+    param([string]$HostAddress)
+
+    $parsedIpAddress = $null
+    if ([System.Net.IPAddress]::TryParse($HostAddress, [ref]$parsedIpAddress)) {
+        if (
+            $parsedIpAddress.Equals([System.Net.IPAddress]::Any) -or
+            $parsedIpAddress.Equals([System.Net.IPAddress]::IPv6Any)
+        ) {
+            return "localhost"
+        }
+
+        if ($parsedIpAddress.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6) {
+            return "[$HostAddress]"
+        }
+    }
+
+    return $HostAddress
+}
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 if (Test-Path (Join-Path $ScriptDir "$AppName.exe")) {
     $ReleaseDir = $ScriptDir
@@ -39,6 +108,10 @@ $registeredAsTask = $false
 if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+
+    if ($Service) {
+        Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir
+    }
 
     Copy-Item -Force $BinarySrc (Join-Path $InstallDir "$AppName.exe")
 
@@ -80,11 +153,8 @@ exit /b %APP_EXIT_CODE%
             throw "Missing background service runner script: $RunnerScript"
         }
 
-        # Stop existing service or running instances if any
-        try {
-            Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        } catch {}
-        Get-Process -Name $AppName -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        $StartupShortcut = Get-StartupShortcutPath
+        Remove-Item -Force -Path $StartupShortcut -ErrorAction SilentlyContinue
 
         $Action = New-ScheduledTaskAction `
             -Execute "powershell.exe" `
@@ -113,13 +183,8 @@ exit /b %APP_EXIT_CODE%
             $registeredAsTask = $true
         } catch {
             Write-Warning "Could not register scheduled task: $($_.Exception.Message). Falling back to Startup folder..."
-            $StartupFolder = [Environment]::GetFolderPath('Startup')
-            if (-not (Test-Path $StartupFolder)) {
-                $StartupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
-            }
-            $ShortcutPath = Join-Path $StartupFolder "$AppName.lnk"
             $WshShell = New-Object -ComObject WScript.Shell
-            $Shortcut = $WshShell.CreateShortcut($ShortcutPath)
+            $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
             $Shortcut.TargetPath = "powershell.exe"
             $Shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port"
             $Shortcut.WorkingDirectory = $InstallDir
@@ -151,7 +216,7 @@ if ($Service) {
     }
     Write-Host "  Logs directory:  $(Join-Path $InstallDir 'logs')"
     Write-Host ""
-    $displayHost = if ($HostAddress -eq "0.0.0.0") { "localhost" } else { $HostAddress }
+    $displayHost = Get-DashboardDisplayHost -HostAddress $HostAddress
     Write-Host "Dashboard URL:"
     Write-Host "  http://${displayHost}:${Port}"
 } else {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -59,6 +59,10 @@ function Stop-ExistingServiceInstance {
         Start-Sleep -Milliseconds 250
     }
 
+    if ($runnerHostIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }) {
+        throw "Failed to stop the existing background runner before reinstalling."
+    }
+
     if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
         throw "Failed to stop the existing $ProcessName process before reinstalling."
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -96,7 +96,15 @@ function Get-ScheduledTaskLogonUser {
         }
     } catch {}
 
-    return $env:USERNAME
+    if ($env:USERDOMAIN -and $env:USERNAME) {
+        return "$($env:USERDOMAIN)\$($env:USERNAME)"
+    }
+
+    if ($env:COMPUTERNAME -and $env:USERNAME) {
+        return "$($env:COMPUTERNAME)\$($env:USERNAME)"
+    }
+
+    return $null
 }
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -177,7 +185,11 @@ exit /b %APP_EXIT_CODE%
                 -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
                 -WorkingDirectory $InstallDir
 
-            $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $taskLogonUser
+            if ($taskLogonUser) {
+                $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $taskLogonUser
+            } else {
+                $Trigger = New-ScheduledTaskTrigger -AtLogOn
+            }
 
             $Settings = New-ScheduledTaskSettingsSet `
                 -AllowStartIfOnBatteries `

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -158,23 +158,22 @@ exit /b %APP_EXIT_CODE%
         }
 
         $StartupShortcut = Get-StartupShortcutPath
-        Remove-Item -Force -Path $StartupShortcut -ErrorAction SilentlyContinue
-
-        $Action = New-ScheduledTaskAction `
-            -Execute "powershell.exe" `
-            -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
-            -WorkingDirectory $InstallDir
-
-        $Trigger = New-ScheduledTaskTrigger -AtLogOn
-
-        $Settings = New-ScheduledTaskSettingsSet `
-            -AllowStartIfOnBatteries `
-            -DontStopIfGoingOnBatteries `
-            -ExecutionTimeLimit ([TimeSpan]::Zero) `
-            -RestartCount 3 `
-            -RestartInterval (New-TimeSpan -Minutes 1)
 
         try {
+            $Action = New-ScheduledTaskAction `
+                -Execute "powershell.exe" `
+                -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
+                -WorkingDirectory $InstallDir
+
+            $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+
+            $Settings = New-ScheduledTaskSettingsSet `
+                -AllowStartIfOnBatteries `
+                -DontStopIfGoingOnBatteries `
+                -ExecutionTimeLimit ([TimeSpan]::Zero) `
+                -RestartCount 3 `
+                -RestartInterval (New-TimeSpan -Minutes 1)
+
             Register-ScheduledTask `
                 -TaskName $TaskName `
                 -Action $Action `
@@ -185,8 +184,16 @@ exit /b %APP_EXIT_CODE%
 
             Start-ScheduledTask -TaskName $TaskName
             $registeredAsTask = $true
+
+            # Registration in Task Scheduler succeeded; remove any stale Startup folder shortcut
+            # to avoid dual launches on logon.
+            Remove-Item -Force -Path $StartupShortcut -ErrorAction SilentlyContinue
         } catch {
             Write-Warning "Could not register scheduled task: $($_.Exception.Message). Falling back to Startup folder..."
+            try {
+                Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+            } catch {}
+
             $WshShell = New-Object -ComObject WScript.Shell
             $Shortcut = $WshShell.CreateShortcut($StartupShortcut)
             $Shortcut.TargetPath = "powershell.exe"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -411,7 +411,12 @@ exit /b %APP_EXIT_CODE%
                 Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
             } catch {}
 
-            if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+            $taskStillExists = $false
+            try {
+                $taskStillExists = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
+            } catch {}
+
+            if ($taskStillExists) {
                 throw "Could not register scheduled task and failed to unregister existing task '$TaskName'. Aborting fallback to prevent duplicate execution."
             }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,7 +5,9 @@ param(
         else { Join-Path $HOME "AppData\Local\TokenUsageInsights" }
     ),
     [string]$BinDir = $(Join-Path $HOME "bin"),
-    [int]$Port = 3003
+    [string]$HostAddress = $(if ($env:HOST) { $env:HOST } else { "0.0.0.0" }),
+    [int]$Port = $(if ($env:PORT) { [int]$env:PORT } else { 3003 }),
+    [switch]$Service
 )
 
 $ErrorActionPreference = "Stop"
@@ -30,6 +32,9 @@ foreach ($RequiredItem in @("static", "pricing.csv")) {
         throw "Incomplete release package: missing $RequiredItem in $ReleaseDir"
     }
 }
+
+$TaskName = "TokenUsageInsights"
+$registeredAsTask = $false
 
 if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
@@ -60,6 +65,7 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     @"
 @echo off
 setlocal
+set "HOST=$HostAddress"
 set "PORT=$Port"
 pushd "$BatchInstallDir"
 "$BatchInstallDir\$AppName.exe" %*
@@ -67,6 +73,65 @@ set "APP_EXIT_CODE=%ERRORLEVEL%"
 popd
 exit /b %APP_EXIT_CODE%
 "@ | Set-Content -Encoding ASCII $Shim
+
+    if ($Service) {
+        $RunnerScript = Join-Path $InstallDir "scripts\run-service.ps1"
+        if (!(Test-Path $RunnerScript)) {
+            throw "Missing background service runner script: $RunnerScript"
+        }
+
+        # Stop existing service or running instances if any
+        try {
+            Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        } catch {}
+        Get-Process -Name $AppName -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+        $Action = New-ScheduledTaskAction `
+            -Execute "powershell.exe" `
+            -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
+            -WorkingDirectory $InstallDir
+
+        $Trigger = New-ScheduledTaskTrigger -AtLogOn
+
+        $Settings = New-ScheduledTaskSettingsSet `
+            -AllowStartIfOnBatteries `
+            -DontStopIfGoingOnBatteries `
+            -ExecutionTimeLimit ([TimeSpan]::Zero) `
+            -RestartCount 3 `
+            -RestartInterval (New-TimeSpan -Minutes 1)
+
+        try {
+            Register-ScheduledTask `
+                -TaskName $TaskName `
+                -Action $Action `
+                -Trigger $Trigger `
+                -Settings $Settings `
+                -Description "Token 戰情室 Dashboard Background Service" `
+                -Force | Out-Null
+
+            Start-ScheduledTask -TaskName $TaskName
+            $registeredAsTask = $true
+        } catch {
+            Write-Warning "Could not register scheduled task: $($_.Exception.Message). Falling back to Startup folder..."
+            $StartupFolder = [Environment]::GetFolderPath('Startup')
+            if (-not (Test-Path $StartupFolder)) {
+                $StartupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
+            }
+            $ShortcutPath = Join-Path $StartupFolder "$AppName.lnk"
+            $WshShell = New-Object -ComObject WScript.Shell
+            $Shortcut = $WshShell.CreateShortcut($ShortcutPath)
+            $Shortcut.TargetPath = "powershell.exe"
+            $Shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port"
+            $Shortcut.WorkingDirectory = $InstallDir
+            $Shortcut.WindowStyle = 7
+            $Shortcut.Description = "Token 戰情室 Dashboard Background Service"
+            $Shortcut.Save()
+
+            Start-Process -FilePath "powershell.exe" `
+                -ArgumentList "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$RunnerScript`" -InstallDir `"$InstallDir`" -HostAddress `"$HostAddress`" -Port $Port" `
+                -WorkingDirectory $InstallDir -WindowStyle Hidden
+        }
+    }
 }
 
 Write-Host "Token 戰情室 installed."
@@ -77,5 +142,19 @@ Write-Host ""
 Write-Host "Executable shim:"
 Write-Host "  $(Join-Path $BinDir "$AppName.cmd")"
 Write-Host ""
-Write-Host "Run:"
-Write-Host "  $(Join-Path $BinDir "$AppName.cmd")"
+if ($Service) {
+    Write-Host "Background service:"
+    if ($registeredAsTask) {
+        Write-Host "  Registered task: $TaskName (Task Scheduler)"
+    } else {
+        Write-Host "  Registered in:   Startup folder"
+    }
+    Write-Host "  Logs directory:  $(Join-Path $InstallDir 'logs')"
+    Write-Host ""
+    $displayHost = if ($HostAddress -eq "0.0.0.0") { "localhost" } else { $HostAddress }
+    Write-Host "Dashboard URL:"
+    Write-Host "  http://${displayHost}:${Port}"
+} else {
+    Write-Host "Run:"
+    Write-Host "  $(Join-Path $BinDir "$AppName.cmd")"
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,14 +16,29 @@ $InstallDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($
 $BinDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($BinDir))
 
 function Get-StartupShortcutPath {
+    param([switch]$EnsureDirectory)
+
     $startupFolder = $env:TOKEN_USAGE_INSIGHTS_STARTUP_DIR
     if (-not $startupFolder) {
         $startupFolder = [Environment]::GetFolderPath('Startup')
     }
-    if (-not (Test-Path $startupFolder)) {
-        $startupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
+
+    $fallbackStartupFolder = $null
+    if ($env:APPDATA) {
+        $fallbackStartupFolder = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
     }
-    if (-not (Test-Path $startupFolder)) {
+
+    if (-not $startupFolder) {
+        $startupFolder = $fallbackStartupFolder
+    } elseif (
+        -not (Test-Path $startupFolder) -and
+        $fallbackStartupFolder -and
+        -not $startupFolder.Equals($fallbackStartupFolder, [System.StringComparison]::OrdinalIgnoreCase)
+    ) {
+        $startupFolder = $fallbackStartupFolder
+    }
+
+    if ($EnsureDirectory -and $startupFolder -and -not (Test-Path $startupFolder)) {
         New-Item -ItemType Directory -Force -Path $startupFolder | Out-Null
     }
 
@@ -56,7 +71,7 @@ function Get-RunnerScriptPathFromArguments {
 
 function Stop-ExistingServiceInstance {
     param(
-        [string]$TaskName,
+        [string[]]$TaskNames,
         [string]$ProcessName,
         [string]$InstallDir
     )
@@ -66,12 +81,14 @@ function Stop-ExistingServiceInstance {
     $null = $runnerScriptPaths.Add($runnerScriptPath)
 
     try {
-        $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        if ($existingTask -and $existingTask.Actions) {
-            foreach ($action in @($existingTask.Actions)) {
-                $taskRunnerPath = Get-RunnerScriptPathFromArguments -Arguments $action.Arguments
-                if ($taskRunnerPath) {
-                    $null = $runnerScriptPaths.Add($taskRunnerPath)
+        foreach ($knownTaskName in @($TaskNames | Where-Object { $_ } | Select-Object -Unique)) {
+            $existingTask = Get-ScheduledTask -TaskName $knownTaskName -ErrorAction SilentlyContinue
+            if ($existingTask -and $existingTask.Actions) {
+                foreach ($action in @($existingTask.Actions)) {
+                    $taskRunnerPath = Get-RunnerScriptPathFromArguments -Arguments $action.Arguments
+                    if ($taskRunnerPath) {
+                        $null = $runnerScriptPaths.Add($taskRunnerPath)
+                    }
                 }
             }
         }
@@ -132,7 +149,9 @@ function Stop-ExistingServiceInstance {
     }
 
     try {
-        Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        foreach ($knownTaskName in @($TaskNames | Where-Object { $_ } | Select-Object -Unique)) {
+            Stop-ScheduledTask -TaskName $knownTaskName -ErrorAction SilentlyContinue
+        }
     } catch {}
 
     $runnerHosts = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
@@ -285,16 +304,18 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 
     $existingTask = $false
+    $legacyTaskName = $null
+    $taskNamesToStop = @($TaskName)
     try {
         $existingTask = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
         if (-not $existingTask) {
-            $legacyTask = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+            $legacyTaskName = "TokenUsageInsights"
+            $legacyTask = Get-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
             if ($legacyTask) {
                 $existingTask = $true
-                try {
-                    Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
-                    Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
-                } catch {}
+                $taskNamesToStop += $legacyTaskName
+            } else {
+                $legacyTaskName = $null
             }
         }
     } catch {}
@@ -306,7 +327,13 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     $hadPersistentServiceRegistration = $hadScheduledTaskBeforeStop -or $existingShortcut
 
     if ($Service -or $hadPersistentServiceRegistration) {
-        Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir
+        Stop-ExistingServiceInstance -TaskNames $taskNamesToStop -ProcessName $AppName -InstallDir $InstallDir
+    }
+
+    if ($legacyTaskName) {
+        try {
+            Unregister-ScheduledTask -TaskName $legacyTaskName -Confirm:$false -ErrorAction SilentlyContinue
+        } catch {}
     }
 
     Copy-Item -Force $BinarySrc (Join-Path $InstallDir "$AppName.exe")
@@ -388,6 +415,7 @@ exit /b %APP_EXIT_CODE%
                 throw "Could not register scheduled task and failed to unregister existing task '$TaskName'. Aborting fallback to prevent duplicate execution."
             }
 
+            $startupShortcutPath = Get-StartupShortcutPath -EnsureDirectory
             Set-StartupShortcutForRunner `
                 -ShortcutPath $startupShortcutPath `
                 -RunnerScript $RunnerScript `
@@ -426,6 +454,7 @@ exit /b %APP_EXIT_CODE%
         $startupShortcutReady = Test-Path $startupShortcutPath
         if ($hadStartupShortcutBeforeStop -and (Test-Path $runnerScript) -and -not $startupShortcutReady) {
             try {
+                $startupShortcutPath = Get-StartupShortcutPath -EnsureDirectory
                 Set-StartupShortcutForRunner `
                     -ShortcutPath $startupShortcutPath `
                     -RunnerScript $runnerScript `

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -31,6 +31,10 @@ function Stop-ExistingServiceInstance {
         [string]$InstallDir
     )
 
+    $runnerScriptPath = [IO.Path]::GetFullPath((Join-Path $InstallDir "scripts\run-service.ps1"))
+    $quotedRunnerFileArgument = "-File `"$runnerScriptPath`""
+    $unquotedRunnerFileArgument = "-File $runnerScriptPath"
+
     try {
         Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     } catch {}
@@ -38,8 +42,10 @@ function Stop-ExistingServiceInstance {
     $runnerHosts = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
         ($_.Name -in @("powershell.exe", "pwsh.exe")) -and
         $_.CommandLine -and
-        $_.CommandLine.IndexOf("run-service.ps1", [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -and
-        $_.CommandLine.IndexOf($InstallDir, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+        (
+            $_.CommandLine.IndexOf($quotedRunnerFileArgument, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+            $_.CommandLine.IndexOf($unquotedRunnerFileArgument, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+        )
     })
     $runnerHostIds = @($runnerHosts | ForEach-Object { $_.ProcessId })
     foreach ($runnerHost in $runnerHosts) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -308,7 +308,7 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     $taskNamesToStop = @($TaskName)
     try {
         $existingTask = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
-        if (-not $existingTask) {
+        if ($TaskName -ne "TokenUsageInsights") {
             $legacyTaskName = "TokenUsageInsights"
             $legacyTask = Get-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
             if ($legacyTask) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -275,6 +275,9 @@ foreach ($RequiredItem in @("static", "pricing.csv")) {
 }
 
 $TaskName = "TokenUsageInsights"
+if ($env:USERNAME) {
+    $TaskName = "TokenUsageInsights_$env:USERNAME"
+}
 $registeredAsTask = $false
 
 if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
@@ -284,6 +287,16 @@ if ($PSCmdlet.ShouldProcess($InstallDir, "Install Token Usage Insights")) {
     $existingTask = $false
     try {
         $existingTask = [bool](Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)
+        if (-not $existingTask) {
+            $legacyTask = Get-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+            if ($legacyTask) {
+                $existingTask = $true
+                try {
+                    Stop-ScheduledTask -TaskName "TokenUsageInsights" -ErrorAction SilentlyContinue
+                    Unregister-ScheduledTask -TaskName "TokenUsageInsights" -Confirm:$false -ErrorAction SilentlyContinue
+                } catch {}
+            }
+        }
     } catch {}
     $hadScheduledTaskBeforeStop = $existingTask
     $hadStartupShortcutBeforeStop = $false
@@ -371,6 +384,10 @@ exit /b %APP_EXIT_CODE%
                 Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
             } catch {}
 
+            if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+                throw "Could not register scheduled task and failed to unregister existing task '$TaskName'. Aborting fallback to prevent duplicate execution."
+            }
+
             Set-StartupShortcutForRunner `
                 -ShortcutPath $startupShortcutPath `
                 -RunnerScript $RunnerScript `
@@ -394,11 +411,13 @@ exit /b %APP_EXIT_CODE%
 
             # Registration in Task Scheduler succeeded; remove any stale Startup folder shortcut
             # to avoid dual launches on logon.
-            if ($PSCmdlet.ShouldProcess($startupShortcutPath, "Remove stale Startup shortcut")) {
-                try {
-                    Remove-Item -Force -Path $startupShortcutPath -ErrorAction Stop
-                } catch {
-                    Write-Warning "Scheduled task registered, but removing the stale Startup shortcut failed: $($_.Exception.Message)"
+            if (Test-Path $startupShortcutPath) {
+                if ($PSCmdlet.ShouldProcess($startupShortcutPath, "Remove stale Startup shortcut")) {
+                    try {
+                        Remove-Item -Force -Path $startupShortcutPath -ErrorAction Stop
+                    } catch {
+                        throw "Scheduled task registered, but removing the stale Startup shortcut failed: $($_.Exception.Message). Please remove it manually to avoid duplicate execution: $startupShortcutPath"
+                    }
                 }
             }
         }

--- a/scripts/run-service.ps1
+++ b/scripts/run-service.ps1
@@ -28,6 +28,21 @@ if (!(Test-Path $LogDir)) {
 $OutLog = Join-Path $LogDir "$AppName.out.log"
 $ErrLog = Join-Path $LogDir "$AppName.err.log"
 
+if (Test-Path $OutLog) {
+    $outItem = Get-Item $OutLog -ErrorAction SilentlyContinue
+    if ($outItem -and $outItem.Length -gt 0) {
+        Add-Content -LiteralPath (Join-Path $LogDir "$AppName.history.out.log") -Value (Get-Content -LiteralPath $OutLog) -ErrorAction SilentlyContinue
+        Move-Item -LiteralPath $OutLog -Destination (Join-Path $LogDir "$AppName.prev.out.log") -Force -ErrorAction SilentlyContinue
+    }
+}
+if (Test-Path $ErrLog) {
+    $errItem = Get-Item $ErrLog -ErrorAction SilentlyContinue
+    if ($errItem -and $errItem.Length -gt 0) {
+        Add-Content -LiteralPath (Join-Path $LogDir "$AppName.history.err.log") -Value (Get-Content -LiteralPath $ErrLog) -ErrorAction SilentlyContinue
+        Move-Item -LiteralPath $ErrLog -Destination (Join-Path $LogDir "$AppName.prev.err.log") -Force -ErrorAction SilentlyContinue
+    }
+}
+
 $Process = Start-Process -FilePath $Exe `
     -WorkingDirectory $InstallDir `
     -WindowStyle Hidden `

--- a/scripts/run-service.ps1
+++ b/scripts/run-service.ps1
@@ -28,6 +28,7 @@ if (!(Test-Path $LogDir)) {
 $OutLog = Join-Path $LogDir "$AppName.out.log"
 $ErrLog = Join-Path $LogDir "$AppName.err.log"
 $MaxHistoryBytes = 5MB
+$MaxActiveLogBytes = 10MB
 
 function Rotate-ServiceLog {
     param(
@@ -117,33 +118,62 @@ function Rotate-ServiceLog {
             Move-Item -LiteralPath $CurrentLogPath -Destination $PreviousLogPath -Force -ErrorAction Stop
         } catch {
             Write-Warning "Log rotation move failed for ${CurrentLogPath}: $($_.Exception.Message)"
-            Remove-Item -LiteralPath $CurrentLogPath -Force -ErrorAction SilentlyContinue
-            New-Item -ItemType File -Path $CurrentLogPath -Force | Out-Null
+            $timestamp = (Get-Date).ToString("yyyyMMddHHmmss")
+            $fallbackPrev = "${PreviousLogPath}.${timestamp}.bak"
+            try {
+                Move-Item -LiteralPath $CurrentLogPath -Destination $fallbackPrev -Force -ErrorAction Stop
+            } catch {
+                Write-Warning "Fallback log rotation move failed for ${CurrentLogPath}: $($_.Exception.Message)"
+            }
         }
     }
 }
 
-Rotate-ServiceLog `
-    -CurrentLogPath $OutLog `
-    -PreviousLogPath (Join-Path $LogDir "$AppName.prev.out.log") `
-    -HistoryLogPath (Join-Path $LogDir "$AppName.history.out.log")
-Rotate-ServiceLog `
-    -CurrentLogPath $ErrLog `
-    -PreviousLogPath (Join-Path $LogDir "$AppName.prev.err.log") `
-    -HistoryLogPath (Join-Path $LogDir "$AppName.history.err.log")
+while ($true) {
+    Rotate-ServiceLog `
+        -CurrentLogPath $OutLog `
+        -PreviousLogPath (Join-Path $LogDir "$AppName.prev.out.log") `
+        -HistoryLogPath (Join-Path $LogDir "$AppName.history.out.log")
+    Rotate-ServiceLog `
+        -CurrentLogPath $ErrLog `
+        -PreviousLogPath (Join-Path $LogDir "$AppName.prev.err.log") `
+        -HistoryLogPath (Join-Path $LogDir "$AppName.history.err.log")
 
-$Process = Start-Process -FilePath $Exe `
-    -WorkingDirectory $InstallDir `
-    -WindowStyle Hidden `
-    -RedirectStandardOutput $OutLog `
-    -RedirectStandardError $ErrLog `
-    -PassThru
+    $Process = $null
+    $Process = Start-Process -FilePath $Exe `
+        -WorkingDirectory $InstallDir `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $OutLog `
+        -RedirectStandardError $ErrLog `
+        -PassThru
 
-try {
-    $Process.WaitForExit()
-    exit $Process.ExitCode
-} finally {
-    if ($Process -and -not $Process.HasExited) {
-        Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+    $restartForLogRotation = $false
+    try {
+        while (-not $Process.WaitForExit(5000)) {
+            $outItem = Get-Item -LiteralPath $OutLog -ErrorAction SilentlyContinue
+            $errItem = Get-Item -LiteralPath $ErrLog -ErrorAction SilentlyContinue
+            if (($outItem -and $outItem.Length -ge $MaxActiveLogBytes) -or ($errItem -and $errItem.Length -ge $MaxActiveLogBytes)) {
+                Write-Warning "Active log size exceeded ${MaxActiveLogBytes} bytes. Restarting service to rotate logs..."
+                $restartForLogRotation = $true
+                Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+                try {
+                    $null = $Process.WaitForExit(5000)
+                } catch {}
+                break
+            }
+        }
+    } finally {
+        if ($Process -and -not $Process.HasExited) {
+            Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+            try {
+                $null = $Process.WaitForExit(5000)
+            } catch {}
+        }
     }
+
+    if ($restartForLogRotation) {
+        continue
+    }
+
+    exit $Process.ExitCode
 }

--- a/scripts/run-service.ps1
+++ b/scripts/run-service.ps1
@@ -51,7 +51,9 @@ $Process = Start-Process -FilePath $Exe `
     -PassThru
 
 try {
-    $Process.WaitForExit()
+    while (-not $Process.WaitForExit(500)) {
+        # Active wait until process exits
+    }
     exit $Process.ExitCode
 } finally {
     if ($Process -and -not $Process.HasExited) {

--- a/scripts/run-service.ps1
+++ b/scripts/run-service.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+  Background service runner for Token 戰情室 on Windows.
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallDir = (Split-Path -Parent $PSScriptRoot),
+    [string]$HostAddress = $(if ($env:HOST) { $env:HOST } else { "0.0.0.0" }),
+    [int]$Port = $(if ($env:PORT) { [int]$env:PORT } else { 3003 })
+)
+
+$ErrorActionPreference = "Stop"
+$AppName = "token-usage-insights"
+$InstallDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($InstallDir))
+
+$env:PORT = "$Port"
+$env:HOST = "$HostAddress"
+
+$Exe = Join-Path $InstallDir "$AppName.exe"
+if (!(Test-Path $Exe)) {
+    throw "Executable not found: $Exe"
+}
+
+$LogDir = Join-Path $InstallDir "logs"
+if (!(Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+}
+$OutLog = Join-Path $LogDir "$AppName.out.log"
+$ErrLog = Join-Path $LogDir "$AppName.err.log"
+
+$Process = Start-Process -FilePath $Exe `
+    -WorkingDirectory $InstallDir `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $OutLog `
+    -RedirectStandardError $ErrLog `
+    -PassThru
+
+try {
+    $Process.WaitForExit()
+    exit $Process.ExitCode
+} finally {
+    if ($Process -and -not $Process.HasExited) {
+        Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/run-service.ps1
+++ b/scripts/run-service.ps1
@@ -27,21 +27,110 @@ if (!(Test-Path $LogDir)) {
 }
 $OutLog = Join-Path $LogDir "$AppName.out.log"
 $ErrLog = Join-Path $LogDir "$AppName.err.log"
+$MaxHistoryBytes = 5MB
 
-if (Test-Path $OutLog) {
-    $outItem = Get-Item $OutLog -ErrorAction SilentlyContinue
-    if ($outItem -and $outItem.Length -gt 0) {
-        Add-Content -LiteralPath (Join-Path $LogDir "$AppName.history.out.log") -Value (Get-Content -LiteralPath $OutLog) -ErrorAction SilentlyContinue
-        Move-Item -LiteralPath $OutLog -Destination (Join-Path $LogDir "$AppName.prev.out.log") -Force -ErrorAction SilentlyContinue
+function Rotate-ServiceLog {
+    param(
+        [string]$CurrentLogPath,
+        [string]$PreviousLogPath,
+        [string]$HistoryLogPath
+    )
+
+    if (!(Test-Path $CurrentLogPath)) {
+        return
+    }
+
+    $currentLogItem = Get-Item -LiteralPath $CurrentLogPath -ErrorAction SilentlyContinue
+    if (-not $currentLogItem -or $currentLogItem.Length -le 0) {
+        return
+    }
+
+    try {
+        $rotationCompleted = $false
+        $historyLogItem = Get-Item -LiteralPath $HistoryLogPath -ErrorAction SilentlyContinue
+        $historyLogLength = if ($historyLogItem) { $historyLogItem.Length } else { 0 }
+        $currentLogLength = $currentLogItem.Length
+        $resetHistory = $currentLogLength -ge $MaxHistoryBytes -or ($historyLogLength + $currentLogLength) -gt $MaxHistoryBytes
+        $bytesToCopy = [Math]::Min([int64]$currentLogLength, [int64]$MaxHistoryBytes)
+        if (-not $resetHistory) {
+            $remainingHistoryBudget = [Math]::Max([int64]0, [int64]($MaxHistoryBytes - $historyLogLength))
+            $bytesToCopy = [Math]::Min($bytesToCopy, $remainingHistoryBudget)
+        }
+        if ($bytesToCopy -le 0) {
+            $rotationCompleted = $true
+        } else {
+            $readStream = [System.IO.File]::Open($CurrentLogPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+            try {
+                $historyFileMode = if ($resetHistory) { [System.IO.FileMode]::Create } else { [System.IO.FileMode]::Append }
+                $writeStream = [System.IO.File]::Open($HistoryLogPath, $historyFileMode, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+                try {
+                    if ($currentLogLength -gt $bytesToCopy) {
+                        $readStream.Seek(-$bytesToCopy, [System.IO.SeekOrigin]::End) | Out-Null
+
+                        while ($true) {
+                            $candidateByte = $readStream.ReadByte()
+                            if ($candidateByte -lt 0) {
+                                break
+                            }
+                            if (($candidateByte -band 0xC0) -ne 0x80) {
+                                $readStream.Seek(-1, [System.IO.SeekOrigin]::Current) | Out-Null
+                                break
+                            }
+                        }
+
+                        while ($true) {
+                            $nextByte = $readStream.ReadByte()
+                            if ($nextByte -lt 0 -or $nextByte -eq 10) {
+                                if ($nextByte -eq 10) {
+                                    $readStream.Seek(-1, [System.IO.SeekOrigin]::Current) | Out-Null
+                                }
+                                break
+                            }
+                            if ($nextByte -eq 13) {
+                                $followingByte = $readStream.ReadByte()
+                                if ($followingByte -eq 10) {
+                                    $readStream.Seek(-2, [System.IO.SeekOrigin]::Current) | Out-Null
+                                } elseif ($followingByte -ge 0) {
+                                    $readStream.Seek(-1, [System.IO.SeekOrigin]::Current) | Out-Null
+                                } else {
+                                    $readStream.Seek(-1, [System.IO.SeekOrigin]::Current) | Out-Null
+                                }
+                                break
+                            }
+                        }
+                    }
+                    $readStream.CopyTo($writeStream)
+                    $rotationCompleted = $true
+                } finally {
+                    $writeStream.Dispose()
+                }
+            } finally {
+                $readStream.Dispose()
+            }
+        }
+    } catch {
+        Write-Warning "Log rotation failed for ${CurrentLogPath}: $($_.Exception.Message)"
+    }
+
+    if ($rotationCompleted) {
+        try {
+            Move-Item -LiteralPath $CurrentLogPath -Destination $PreviousLogPath -Force -ErrorAction Stop
+        } catch {
+            Write-Warning "Log rotation move failed for ${CurrentLogPath}: $($_.Exception.Message)"
+            Remove-Item -LiteralPath $CurrentLogPath -Force -ErrorAction SilentlyContinue
+            New-Item -ItemType File -Path $CurrentLogPath -Force | Out-Null
+        }
     }
 }
-if (Test-Path $ErrLog) {
-    $errItem = Get-Item $ErrLog -ErrorAction SilentlyContinue
-    if ($errItem -and $errItem.Length -gt 0) {
-        Add-Content -LiteralPath (Join-Path $LogDir "$AppName.history.err.log") -Value (Get-Content -LiteralPath $ErrLog) -ErrorAction SilentlyContinue
-        Move-Item -LiteralPath $ErrLog -Destination (Join-Path $LogDir "$AppName.prev.err.log") -Force -ErrorAction SilentlyContinue
-    }
-}
+
+Rotate-ServiceLog `
+    -CurrentLogPath $OutLog `
+    -PreviousLogPath (Join-Path $LogDir "$AppName.prev.out.log") `
+    -HistoryLogPath (Join-Path $LogDir "$AppName.history.out.log")
+Rotate-ServiceLog `
+    -CurrentLogPath $ErrLog `
+    -PreviousLogPath (Join-Path $LogDir "$AppName.prev.err.log") `
+    -HistoryLogPath (Join-Path $LogDir "$AppName.history.err.log")
 
 $Process = Start-Process -FilePath $Exe `
     -WorkingDirectory $InstallDir `
@@ -51,9 +140,7 @@ $Process = Start-Process -FilePath $Exe `
     -PassThru
 
 try {
-    while (-not $Process.WaitForExit(500)) {
-        # Active wait until process exits
-    }
+    $Process.WaitForExit()
     exit $Process.ExitCode
 } finally {
     if ($Process -and -not $Process.HasExited) {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -86,7 +86,8 @@ function Invoke-InstallServiceTest {
     param(
         [string]$HostAddress,
         [int]$Port,
-        [switch]$FailScheduledTaskAction
+        [switch]$FailScheduledTaskAction,
+        [switch]$WhatIf
     )
 
     $tempRoot = Join-Path $Root ([guid]::NewGuid())
@@ -100,16 +101,18 @@ function Invoke-InstallServiceTest {
     $env:APPDATA = Join-Path $tempRoot "AppData\Roaming"
     $env:USERNAME = "test-user"
     $env:USERDOMAIN = "test-domain"
+    $startupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
 
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "static") | Out-Null
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "shell") | Out-Null
     New-Item -ItemType Directory -Force -Path $scriptDir | Out-Null
-    New-Item -ItemType Directory -Force -Path $env:APPDATA | Out-Null
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $startupShortcut) | Out-Null
 
     Set-Content -LiteralPath (Join-Path $releaseDir "token-usage-insights.exe") -Value "binary"
     Set-Content -LiteralPath (Join-Path $releaseDir "pricing.csv") -Value "model,input,output"
     Copy-Item -LiteralPath (Join-Path $PSScriptRoot "install.ps1") -Destination (Join-Path $scriptDir "install.ps1")
     Set-Content -LiteralPath (Join-Path $scriptDir "run-service.ps1") -Value "Write-Host 'runner'"
+    Set-Content -LiteralPath $startupShortcut -Value "shortcut"
 
     $global:serviceEvents = New-Object System.Collections.Generic.List[string]
     $global:hostMessages = New-Object System.Collections.Generic.List[string]
@@ -291,13 +294,25 @@ function Invoke-InstallServiceTest {
     }
 
     try {
-        & (Join-Path $scriptDir "install.ps1") -InstallDir $installDir -BinDir $binDir -HostAddress $HostAddress -Port $Port -Service
+        $arguments = @{
+            InstallDir = $installDir
+            BinDir = $binDir
+            HostAddress = $HostAddress
+            Port = $Port
+            Service = $true
+        }
+        if ($WhatIf) {
+            $arguments["WhatIf"] = $true
+        }
+
+        & (Join-Path $scriptDir "install.ps1") @arguments
 
         [pscustomobject]@{
             Events = @($global:serviceEvents)
             Output = @($global:hostMessages)
             TriggerUser = $global:scheduledTaskTriggerUser
             OtherRunnerStopped = (-not $global:otherRunnerProcessAlive)
+            StartupShortcutExists = (Test-Path -LiteralPath $startupShortcut)
         }
     } finally {
         foreach ($functionName in @(
@@ -424,6 +439,9 @@ try {
     Assert-True ($installFallbackResult.Events -contains "CreateShortcut") "install.ps1 should create a Startup shortcut when scheduled task registration setup fails."
     Assert-True ($installFallbackResult.Events -contains "StartFallbackProcess") "install.ps1 should start the fallback background runner when scheduled task setup fails."
     Assert-True ($installFallbackResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should report Startup folder registration after falling back."
+
+    $installWhatIfResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -WhatIf
+    Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -87,6 +87,7 @@ function Invoke-InstallServiceTest {
         [string]$HostAddress,
         [int]$Port,
         [switch]$FailScheduledTaskAction,
+        [switch]$FailStartScheduledTask,
         [switch]$WhatIf
     )
 
@@ -119,10 +120,13 @@ function Invoke-InstallServiceTest {
     $global:runnerProcessAlive = $true
     $global:otherRunnerProcessAlive = $true
     $global:appProcessAlive = $true
+    $global:otherAppProcessAlive = $true
     $global:scheduledTaskTriggerUser = $null
     $runnerCommandLine = "powershell.exe -File `"$installDir\scripts\run-service.ps1`" -InstallDir `"$installDir`""
     $otherInstallDir = "$installDir-old"
     $otherRunnerCommandLine = "powershell.exe -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
+    $appExecutablePath = "$installDir\token-usage-insights.exe"
+    $otherAppExecutablePath = "$otherInstallDir\token-usage-insights.exe"
 
     function Stop-ScheduledTask {
         [CmdletBinding()]
@@ -147,6 +151,22 @@ function Invoke-InstallServiceTest {
                 CommandLine = $otherRunnerCommandLine
             }
         }
+        if ($global:appProcessAlive) {
+            $processes += [pscustomobject]@{
+                Name = "token-usage-insights.exe"
+                ProcessId = 221
+                CommandLine = "`"$appExecutablePath`""
+                ExecutablePath = $appExecutablePath
+            }
+        }
+        if ($global:otherAppProcessAlive) {
+            $processes += [pscustomobject]@{
+                Name = "token-usage-insights.exe"
+                ProcessId = 222
+                CommandLine = "`"$otherAppExecutablePath`""
+                ExecutablePath = $otherAppExecutablePath
+            }
+        }
         return $processes
     }
     function Get-Process {
@@ -159,12 +179,14 @@ function Invoke-InstallServiceTest {
             if (($Id -eq 112) -and $global:otherRunnerProcessAlive) {
                 return [pscustomobject]@{ Id = 112; Name = "powershell" }
             }
+            if (($Id -eq 221) -and $global:appProcessAlive) {
+                return [pscustomobject]@{ Id = 221; Name = "token-usage-insights" }
+            }
+            if (($Id -eq 222) -and $global:otherAppProcessAlive) {
+                return [pscustomobject]@{ Id = 222; Name = "token-usage-insights" }
+            }
 
             return
-        }
-
-        if (($Name -eq "token-usage-insights") -and $global:appProcessAlive) {
-            return [pscustomobject]@{ Id = 222; Name = "token-usage-insights" }
         }
     }
     function Stop-Process {
@@ -184,13 +206,16 @@ function Invoke-InstallServiceTest {
                     $global:otherRunnerProcessAlive = $false
                     $global:serviceEvents.Add("StopOtherRunner")
                 }
+                if ($Id -eq 221) {
+                    $global:appProcessAlive = $false
+                    $global:serviceEvents.Add("StopApp")
+                }
+                if ($Id -eq 222) {
+                    $global:otherAppProcessAlive = $false
+                    $global:serviceEvents.Add("StopOtherApp")
+                }
 
                 return
-            }
-
-            if ($InputObject -and $InputObject.Id -eq 222) {
-                $global:appProcessAlive = $false
-                $global:serviceEvents.Add("StopApp")
             }
         }
     }
@@ -245,6 +270,9 @@ function Invoke-InstallServiceTest {
     function Start-ScheduledTask {
         [CmdletBinding()]
         param([string]$TaskName)
+        if ($FailStartScheduledTask) {
+            throw "Simulated scheduled task start failure."
+        }
         $global:serviceEvents.Add("StartScheduledTask")
     }
     function Unregister-ScheduledTask {
@@ -312,6 +340,7 @@ function Invoke-InstallServiceTest {
             Output = @($global:hostMessages)
             TriggerUser = $global:scheduledTaskTriggerUser
             OtherRunnerStopped = (-not $global:otherRunnerProcessAlive)
+            OtherAppStopped = (-not $global:otherAppProcessAlive)
             StartupShortcutExists = (Test-Path -LiteralPath $startupShortcut)
         }
     } finally {
@@ -333,7 +362,7 @@ function Invoke-InstallServiceTest {
         )) {
             Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
         }
-        Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, otherRunnerProcessAlive, appProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, otherRunnerProcessAlive, appProcessAlive, otherAppProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
         $env:APPDATA = $previousAppData
         $env:USERNAME = $previousUsername
         $env:USERDOMAIN = $previousUserDomain
@@ -429,6 +458,7 @@ try {
     $stopAppIndex = $installIpv6Result.Events.IndexOf("StopApp")
     Assert-True ($copyIndex -gt $stopRunnerIndex -and $copyIndex -gt $stopAppIndex) "install.ps1 should stop existing service processes before copying files."
     Assert-Equal $false $installIpv6Result.OtherRunnerStopped "install.ps1 should not stop a different runner whose install path merely shares a prefix."
+    Assert-Equal $false $installIpv6Result.OtherAppStopped "install.ps1 should not stop a different installed executable whose path merely shares a prefix."
     Assert-True ($installIpv6Result.Output -contains "  http://[::1]:4010") "install.ps1 should bracket IPv6 dashboard URLs."
     Assert-Equal "test-domain\test-user" $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
 
@@ -439,6 +469,12 @@ try {
     Assert-True ($installFallbackResult.Events -contains "CreateShortcut") "install.ps1 should create a Startup shortcut when scheduled task registration setup fails."
     Assert-True ($installFallbackResult.Events -contains "StartFallbackProcess") "install.ps1 should start the fallback background runner when scheduled task setup fails."
     Assert-True ($installFallbackResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should report Startup folder registration after falling back."
+
+    $installPostRegistrationFailureResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -FailStartScheduledTask
+    Assert-True ($installPostRegistrationFailureResult.Events -contains "RegisterScheduledTask") "install.ps1 should still register the scheduled task before a post-registration start failure."
+    Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "CreateShortcut") "install.ps1 should not fall back to the Startup shortcut after scheduled task registration succeeds."
+    Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "StartFallbackProcess") "install.ps1 should not launch the fallback runner after scheduled task registration succeeds."
+    Assert-True ($installPostRegistrationFailureResult.Output -contains "  Registered task: TokenUsageInsights (Task Scheduler)") "install.ps1 should continue reporting the scheduled task after a post-registration start failure."
 
     $installWhatIfResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -WhatIf
     Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -50,13 +50,7 @@ $payload | ConvertTo-Json -Compress | Set-Content -LiteralPath '__CAPTURE_PATH__
 
     function Invoke-RestMethod { @{ tag_name = "v-test" } }
     function Invoke-WebRequest {
-        param(
-            [string]$Uri,
-            [string]$OutFile,
-            [switch]$UseBasicParsing,
-            [parameter(ValueFromRemainingArguments = $true)]
-            $RemainingArgs
-        )
+        param([string]$Uri, [string]$OutFile)
         Set-Content -LiteralPath $OutFile -Value "placeholder"
     }
     function Expand-Archive {
@@ -92,10 +86,12 @@ function Invoke-InstallServiceTest {
     param(
         [string]$HostAddress,
         [int]$Port,
+        [bool]$ServiceInstall = $true,
         [switch]$FailScheduledTaskAction,
         [switch]$FailStartScheduledTask,
-        [switch]$WhatIf,
-        [switch]$ExistingTaskInOtherDir
+        [switch]$TaskTargetsLegacyInstall,
+        [switch]$RemoveStartupShortcutBeforeInstall,
+        [switch]$WhatIf
     )
 
     $tempRoot = Join-Path $Root ([guid]::NewGuid())
@@ -106,10 +102,12 @@ function Invoke-InstallServiceTest {
     $previousAppData = $env:APPDATA
     $previousUsername = $env:USERNAME
     $previousUserDomain = $env:USERDOMAIN
+    $previousStartupOverride = $env:TOKEN_USAGE_INSIGHTS_STARTUP_DIR
     $env:APPDATA = Join-Path $tempRoot "AppData\Roaming"
     $env:USERNAME = "test-user"
     $env:USERDOMAIN = "test-domain"
     $startupShortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup\token-usage-insights.lnk"
+    $env:TOKEN_USAGE_INSIGHTS_STARTUP_DIR = Split-Path -Parent $startupShortcut
 
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "static") | Out-Null
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "shell") | Out-Null
@@ -124,6 +122,7 @@ function Invoke-InstallServiceTest {
 
     $global:serviceEvents = New-Object System.Collections.Generic.List[string]
     $global:hostMessages = New-Object System.Collections.Generic.List[string]
+    $global:mockShortcuts = @{}
     $global:runnerProcessAlive = $true
     $global:otherRunnerProcessAlive = $true
     $global:appProcessAlive = $true
@@ -132,26 +131,9 @@ function Invoke-InstallServiceTest {
     $runnerCommandLine = "powershell.exe -File `"$installDir\scripts\run-service.ps1`" -InstallDir `"$installDir`""
     $otherInstallDir = "$installDir-old"
     $otherRunnerCommandLine = "powershell.exe -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
+    $legacyTaskActionArguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -f:`"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`" -HostAddress `"127.0.0.1`" -Port 3003"
     $appExecutablePath = "$installDir\token-usage-insights.exe"
     $otherAppExecutablePath = "$otherInstallDir\token-usage-insights.exe"
-
-    function Get-ScheduledTask {
-        [CmdletBinding()]
-        param([string]$TaskName)
-        if ($ExistingTaskInOtherDir) {
-            return [pscustomobject]@{
-                TaskName = $TaskName
-                Actions = @(
-                    [pscustomobject]@{
-                        Execute = "powershell.exe"
-                        Argument = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
-                        WorkingDirectory = $otherInstallDir
-                    }
-                )
-            }
-        }
-        return $null
-    }
 
     function Stop-ScheduledTask {
         [CmdletBinding()]
@@ -270,6 +252,17 @@ function Invoke-InstallServiceTest {
         }
         @{ Action = "ok" }
     }
+    function Get-ScheduledTask {
+        [CmdletBinding()]
+        param([string]$TaskName)
+        if ($TaskTargetsLegacyInstall) {
+            return [pscustomobject]@{
+                Actions = @([pscustomobject]@{ Arguments = $legacyTaskActionArguments })
+            }
+        }
+
+        return $null
+    }
     function New-ScheduledTaskTrigger {
         [CmdletBinding()]
         param(
@@ -314,14 +307,24 @@ function Invoke-InstallServiceTest {
             $shell | Add-Member -MemberType ScriptMethod -Name CreateShortcut -Value {
                 param([string]$ShortcutPath)
                 $global:serviceEvents.Add("CreateShortcut")
+                $existingShortcutData = $global:mockShortcuts[$ShortcutPath]
                 $shortcut = [pscustomobject]@{
-                    TargetPath = $null
-                    Arguments = $null
-                    WorkingDirectory = $null
-                    WindowStyle = $null
-                    Description = $null
+                    ShortcutPath = $ShortcutPath
+                    TargetPath = if ($existingShortcutData) { $existingShortcutData.TargetPath } else { $null }
+                    Arguments = if ($existingShortcutData) { $existingShortcutData.Arguments } else { $null }
+                    WorkingDirectory = if ($existingShortcutData) { $existingShortcutData.WorkingDirectory } else { $null }
+                    WindowStyle = if ($existingShortcutData) { $existingShortcutData.WindowStyle } else { $null }
+                    Description = if ($existingShortcutData) { $existingShortcutData.Description } else { $null }
                 }
                 $shortcut | Add-Member -MemberType ScriptMethod -Name Save -Value {
+                    Set-Content -LiteralPath $this.ShortcutPath -Value "shortcut" -Force
+                    $global:mockShortcuts[$this.ShortcutPath] = [pscustomobject]@{
+                        TargetPath = $this.TargetPath
+                        Arguments = $this.Arguments
+                        WorkingDirectory = $this.WorkingDirectory
+                        WindowStyle = $this.WindowStyle
+                        Description = $this.Description
+                    }
                     $global:serviceEvents.Add("SaveShortcut")
                 }
                 return $shortcut
@@ -339,7 +342,11 @@ function Invoke-InstallServiceTest {
             [string]$WorkingDirectory,
             [string]$WindowStyle
         )
-        $global:serviceEvents.Add("StartFallbackProcess")
+        if ($FilePath -eq "powershell.exe") {
+            $global:serviceEvents.Add("StartFallbackProcess")
+        } elseif ($FilePath -eq $startupShortcut) {
+            $global:serviceEvents.Add("StartStartupShortcut")
+        }
     }
     function Write-Host {
         param([Parameter(ValueFromRemainingArguments = $true)]$Arguments)
@@ -347,12 +354,18 @@ function Invoke-InstallServiceTest {
     }
 
     try {
+        if ($RemoveStartupShortcutBeforeInstall) {
+            Remove-Item -LiteralPath $startupShortcut -Force -ErrorAction SilentlyContinue
+        }
+
         $arguments = @{
             InstallDir = $installDir
             BinDir = $binDir
             HostAddress = $HostAddress
             Port = $Port
-            Service = $true
+        }
+        if ($ServiceInstall) {
+            $arguments["Service"] = $true
         }
         if ($WhatIf) {
             $arguments["WhatIf"] = $true
@@ -370,13 +383,13 @@ function Invoke-InstallServiceTest {
         }
     } finally {
         foreach ($functionName in @(
-            "Get-ScheduledTask",
             "Stop-ScheduledTask",
             "Get-CimInstance",
             "Get-Process",
             "Stop-Process",
             "Copy-Item",
             "New-ScheduledTaskAction",
+            "Get-ScheduledTask",
             "New-ScheduledTaskTrigger",
             "New-ScheduledTaskSettingsSet",
             "Register-ScheduledTask",
@@ -388,10 +401,11 @@ function Invoke-InstallServiceTest {
         )) {
             Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
         }
-        Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, otherRunnerProcessAlive, appProcessAlive, otherAppProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable serviceEvents, hostMessages, mockShortcuts, runnerProcessAlive, otherRunnerProcessAlive, appProcessAlive, otherAppProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
         $env:APPDATA = $previousAppData
         $env:USERNAME = $previousUsername
         $env:USERDOMAIN = $previousUserDomain
+        $env:TOKEN_USAGE_INSIGHTS_STARTUP_DIR = $previousStartupOverride
 
         if (Test-Path -LiteralPath $tempRoot) {
             Remove-Item -LiteralPath $tempRoot -Recurse -Force
@@ -498,6 +512,17 @@ try {
     }
     Assert-Equal $expectedTriggerUser $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
 
+    $installLegacyTaskResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -TaskTargetsLegacyInstall
+    Assert-Equal $true $installLegacyTaskResult.OtherRunnerStopped "install.ps1 should stop the runner tied to an existing scheduled task from a previous install directory."
+    Assert-Equal $true $installLegacyTaskResult.OtherAppStopped "install.ps1 should stop the executable tied to an existing scheduled task from a previous install directory."
+
+    $installNonServiceRestartResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ServiceInstall:$false
+    Assert-True ($installNonServiceRestartResult.Events -contains "StartStartupShortcut") "install.ps1 should relaunch the existing Startup shortcut when rerun without -Service."
+
+    $installTaskToStartupMigrationResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ServiceInstall:$false -TaskTargetsLegacyInstall -RemoveStartupShortcutBeforeInstall
+    Assert-Equal $false ($installTaskToStartupMigrationResult.Events -contains "StartStartupShortcut") "install.ps1 should not convert a task-based service into a Startup shortcut when rerun without -Service."
+    Assert-Equal $false ($installTaskToStartupMigrationResult.Events -contains "StartScheduledTask") "install.ps1 should not restart the scheduled task when rerun without -Service."
+
     $installWildcardResult = Invoke-InstallServiceTest -HostAddress "::" -Port 3003
     Assert-True ($installWildcardResult.Output -contains "  http://localhost:3003") "install.ps1 should print localhost for unspecified IPv6 dashboard URLs."
 
@@ -516,10 +541,6 @@ try {
     Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."
     Assert-Equal $false ($installWhatIfResult.Output -contains "Token 戰情室 installed.") "install.ps1 should not output completion message during -WhatIf."
     Assert-Equal $false ($installWhatIfResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should not report service registration during -WhatIf."
-
-    $installCrossDirectoryResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ExistingTaskInOtherDir
-    Assert-Equal $true $installCrossDirectoryResult.OtherRunnerStopped "install.ps1 should stop a previous runner when existing scheduled task pointed to a different directory."
-    Assert-Equal $true $installCrossDirectoryResult.OtherAppStopped "install.ps1 should stop a previous app process when existing scheduled task pointed to a different directory."
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -69,6 +69,18 @@ try {
         Assert-Equal 2 $entries[1].turn_no "$($case.Name) turn number is wrong."
     }
 
+    $installCmd = Get-Command (Resolve-Path (Join-Path $PSScriptRoot "install.ps1")).Path
+    Assert-Equal $true $installCmd.Parameters.ContainsKey("Service") "install.ps1 should declare -Service."
+    Assert-Equal $true $installCmd.Parameters.ContainsKey("HostAddress") "install.ps1 should declare -HostAddress."
+
+    $getCmd = Get-Command (Resolve-Path (Join-Path $PSScriptRoot "get.ps1")).Path
+    Assert-Equal $true $getCmd.Parameters.ContainsKey("Service") "get.ps1 should declare -Service."
+    Assert-Equal $true $getCmd.Parameters.ContainsKey("HostAddress") "get.ps1 should declare -HostAddress."
+
+    $runnerCmd = Get-Command (Resolve-Path (Join-Path $PSScriptRoot "run-service.ps1")).Path
+    Assert-Equal $true $runnerCmd.Parameters.ContainsKey("InstallDir") "run-service.ps1 should declare -InstallDir."
+    Assert-Equal $true $runnerCmd.Parameters.ContainsKey("HostAddress") "run-service.ps1 should declare -HostAddress."
+
     Write-Host "Windows collector smoke tests passed."
 } finally {
     $env:ANTIGRAVITY_DIR = $PreviousAntigravityDir

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -50,7 +50,12 @@ $payload | ConvertTo-Json -Compress | Set-Content -LiteralPath '__CAPTURE_PATH__
 
     function Invoke-RestMethod { @{ tag_name = "v-test" } }
     function Invoke-WebRequest {
-        param([string]$Uri, [string]$OutFile)
+        param(
+            [string]$Uri,
+            [string]$OutFile,
+            [switch]$UseBasicParsing,
+            [Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs
+        )
         Set-Content -LiteralPath $OutFile -Value "placeholder"
     }
     function Expand-Archive {
@@ -87,6 +92,7 @@ function Invoke-InstallServiceTest {
         [string]$HostAddress,
         [int]$Port,
         [bool]$ServiceInstall = $true,
+        [bool]$SeedStartupShortcut = $true,
         [switch]$FailScheduledTaskAction,
         [switch]$FailStartScheduledTask,
         [switch]$TaskTargetsLegacyInstall,
@@ -112,13 +118,15 @@ function Invoke-InstallServiceTest {
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "static") | Out-Null
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "shell") | Out-Null
     New-Item -ItemType Directory -Force -Path $scriptDir | Out-Null
-    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $startupShortcut) | Out-Null
 
     Set-Content -LiteralPath (Join-Path $releaseDir "token-usage-insights.exe") -Value "binary"
     Set-Content -LiteralPath (Join-Path $releaseDir "pricing.csv") -Value "model,input,output"
     Copy-Item -LiteralPath (Join-Path $PSScriptRoot "install.ps1") -Destination (Join-Path $scriptDir "install.ps1")
     Set-Content -LiteralPath (Join-Path $scriptDir "run-service.ps1") -Value "Write-Host 'runner'"
-    Set-Content -LiteralPath $startupShortcut -Value "shortcut"
+    if ($SeedStartupShortcut) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $startupShortcut) | Out-Null
+        Set-Content -LiteralPath $startupShortcut -Value "shortcut"
+    }
 
     $global:serviceEvents = New-Object System.Collections.Generic.List[string]
     $global:hostMessages = New-Object System.Collections.Generic.List[string]
@@ -256,9 +264,12 @@ function Invoke-InstallServiceTest {
         [CmdletBinding()]
         param([string]$TaskName)
         if ($TaskTargetsLegacyInstall) {
-            return [pscustomobject]@{
-                Actions = @([pscustomobject]@{ Arguments = $legacyTaskActionArguments })
+            if ($TaskName -eq "TokenUsageInsights") {
+                return [pscustomobject]@{
+                    Actions = @([pscustomobject]@{ Arguments = $legacyTaskActionArguments })
+                }
             }
+            return $null
         }
 
         return $null
@@ -379,6 +390,7 @@ function Invoke-InstallServiceTest {
             TriggerUser = $global:scheduledTaskTriggerUser
             OtherRunnerStopped = (-not $global:otherRunnerProcessAlive)
             OtherAppStopped = (-not $global:otherAppProcessAlive)
+            StartupDirectoryExists = (Test-Path -LiteralPath (Split-Path -Parent $startupShortcut))
             StartupShortcutExists = (Test-Path -LiteralPath $startupShortcut)
         }
     } finally {
@@ -515,6 +527,9 @@ try {
     $installLegacyTaskResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -TaskTargetsLegacyInstall
     Assert-Equal $true $installLegacyTaskResult.OtherRunnerStopped "install.ps1 should stop the runner tied to an existing scheduled task from a previous install directory."
     Assert-Equal $true $installLegacyTaskResult.OtherAppStopped "install.ps1 should stop the executable tied to an existing scheduled task from a previous install directory."
+
+    $installCleanResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ServiceInstall:$false -SeedStartupShortcut:$false
+    Assert-Equal $false $installCleanResult.StartupDirectoryExists "install.ps1 should not create the Startup folder during a plain install without -Service."
 
     $installNonServiceRestartResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ServiceInstall:$false
     Assert-True ($installNonServiceRestartResult.Events -contains "StartStartupShortcut") "install.ps1 should relaunch the existing Startup shortcut when rerun without -Service."

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -50,6 +50,7 @@ $payload | ConvertTo-Json -Compress | Set-Content -LiteralPath '__CAPTURE_PATH__
 
     function Invoke-RestMethod { @{ tag_name = "v-test" } }
     function Invoke-WebRequest {
+        [CmdletBinding()]
         param(
             [string]$Uri,
             [string]$OutFile,
@@ -575,6 +576,70 @@ try {
     Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."
     Assert-Equal $false ($installWhatIfResult.Output -contains "Token 戰情室 installed.") "install.ps1 should not output completion message during -WhatIf."
     Assert-Equal $false ($installWhatIfResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should not report service registration during -WhatIf."
+
+    # Test Rotate-ServiceLog behavior from run-service.ps1
+    $runServiceContent = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot "run-service.ps1")
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($runServiceContent, [ref]$null, [ref]$null)
+    $fnDef = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $args[0].Name -eq "Rotate-ServiceLog" }, $true)
+    Assert-True ($null -ne $fnDef -and $fnDef.Count -eq 1) "run-service.ps1 should define Rotate-ServiceLog."
+    $MaxHistoryBytes = 500
+    Invoke-Expression $fnDef[0].Extent.Text
+
+    $logTestDir = Join-Path $Root "log-rotation-tests"
+    New-Item -ItemType Directory -Force -Path $logTestDir | Out-Null
+    $testCurrent = Join-Path $logTestDir "test.out.log"
+    $testPrev = Join-Path $logTestDir "test.prev.out.log"
+    $testHist = Join-Path $logTestDir "test.history.out.log"
+
+    # 1. Normal rotation
+    Set-Content -LiteralPath $testCurrent -Value "first batch of logs"
+    Rotate-ServiceLog -CurrentLogPath $testCurrent -PreviousLogPath $testPrev -HistoryLogPath $testHist
+    Assert-Equal $false (Test-Path -LiteralPath $testCurrent) "Rotate-ServiceLog should move the current log."
+    Assert-Equal $true (Test-Path -LiteralPath $testPrev) "Rotate-ServiceLog should create the previous log."
+    Assert-Equal $true (Test-Path -LiteralPath $testHist) "Rotate-ServiceLog should create the history log."
+    Assert-True ((Get-Content -LiteralPath $testHist -Raw) -match "first batch of logs") "Rotate-ServiceLog should append to history."
+
+    # 2. Fallback .bak move when previous destination move fails
+    Set-Content -LiteralPath $testCurrent -Value "second batch of logs"
+    function Move-Item {
+        param([string]$LiteralPath, [string]$Destination, [switch]$Force, $ErrorAction)
+        if ($Destination -eq $testPrev) {
+            throw "Simulated permission denied for previous log"
+        }
+        Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination -Force
+    }
+    try {
+        Rotate-ServiceLog -CurrentLogPath $testCurrent -PreviousLogPath $testPrev -HistoryLogPath $testHist
+    } finally {
+        Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
+    }
+    Assert-Equal $false (Test-Path -LiteralPath $testCurrent) "Rotate-ServiceLog should move the current log via fallback .bak when previous path fails."
+    $bakFiles = @(Get-ChildItem -Path $logTestDir -Filter "test.prev.out.log.*.bak")
+    Assert-True ($bakFiles.Count -ge 1) "Rotate-ServiceLog should create a timestamped .bak file on previous move failure."
+
+    # 3. Preserve active log without data loss if all moves fail
+    Set-Content -LiteralPath $testCurrent -Value "third batch of logs"
+    function Move-Item {
+        param([string]$LiteralPath, [string]$Destination, [switch]$Force, $ErrorAction)
+        throw "All move attempts fail"
+    }
+    try {
+        Rotate-ServiceLog -CurrentLogPath $testCurrent -PreviousLogPath $testPrev -HistoryLogPath $testHist
+    } finally {
+        Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
+    }
+    Assert-Equal $true (Test-Path -LiteralPath $testCurrent) "Rotate-ServiceLog should not delete current log if all move attempts fail."
+    Assert-True ((Get-Content -LiteralPath $testCurrent -Raw) -match "third batch of logs") "Current log content should be preserved on move failures."
+
+    # 4. Process boundary regex verification
+    $mockInstallDir = "C:\Users\tester\AppData\Local\TokenUsageInsights"
+    $escapedDir = [regex]::Escape($mockInstallDir)
+    $boundaryPattern = "(?i)[\s`"'\\]$escapedDir([\\`"'\s]|$)"
+    Assert-True ('powershell -File "' + $mockInstallDir + '\run-service.ps1"' -match $boundaryPattern) "Boundary regex should match double-quoted install dir."
+    Assert-True ("powershell -File '$mockInstallDir\run-service.ps1'" -match $boundaryPattern) "Boundary regex should match single-quoted install dir."
+    Assert-True ("powershell -File $mockInstallDir\run-service.ps1" -match $boundaryPattern) "Boundary regex should match unquoted install dir with leading space."
+    Assert-Equal $false ('powershell -File "' + $mockInstallDir + '-old\run-service.ps1"' -match $boundaryPattern) "Boundary regex should not match install dir prefix collision."
+    Assert-Equal $false ('powershell -File "' + $mockInstallDir + '2\run-service.ps1"' -match $boundaryPattern) "Boundary regex should not match install dir number suffix."
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -96,6 +96,7 @@ function Invoke-InstallServiceTest {
         [switch]$FailScheduledTaskAction,
         [switch]$FailStartScheduledTask,
         [switch]$TaskTargetsLegacyInstall,
+        [switch]$HasCurrentAndLegacyTask,
         [switch]$RemoveStartupShortcutBeforeInstall,
         [switch]$WhatIf
     )
@@ -139,6 +140,7 @@ function Invoke-InstallServiceTest {
     $runnerCommandLine = "powershell.exe -File `"$installDir\scripts\run-service.ps1`" -InstallDir `"$installDir`""
     $otherInstallDir = "$installDir-old"
     $otherRunnerCommandLine = "powershell.exe -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
+    $currentTaskActionArguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$installDir\scripts\run-service.ps1`" -InstallDir `"$installDir`" -HostAddress `"$HostAddress`" -Port $Port"
     $legacyTaskActionArguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -f:`"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`" -HostAddress `"127.0.0.1`" -Port 3003"
     $appExecutablePath = "$installDir\token-usage-insights.exe"
     $otherAppExecutablePath = "$otherInstallDir\token-usage-insights.exe"
@@ -263,6 +265,19 @@ function Invoke-InstallServiceTest {
     function Get-ScheduledTask {
         [CmdletBinding()]
         param([string]$TaskName)
+        if ($HasCurrentAndLegacyTask) {
+            if ($TaskName -eq "TokenUsageInsights_test-user") {
+                return [pscustomobject]@{
+                    Actions = @([pscustomobject]@{ Arguments = $currentTaskActionArguments })
+                }
+            }
+            if ($TaskName -eq "TokenUsageInsights") {
+                return [pscustomobject]@{
+                    Actions = @([pscustomobject]@{ Arguments = $legacyTaskActionArguments })
+                }
+            }
+            return $null
+        }
         if ($TaskTargetsLegacyInstall) {
             if ($TaskName -eq "TokenUsageInsights") {
                 return [pscustomobject]@{
@@ -527,6 +542,10 @@ try {
     $installLegacyTaskResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -TaskTargetsLegacyInstall
     Assert-Equal $true $installLegacyTaskResult.OtherRunnerStopped "install.ps1 should stop the runner tied to an existing scheduled task from a previous install directory."
     Assert-Equal $true $installLegacyTaskResult.OtherAppStopped "install.ps1 should stop the executable tied to an existing scheduled task from a previous install directory."
+
+    $installCurrentAndLegacyTaskResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -SeedStartupShortcut:$false -HasCurrentAndLegacyTask
+    Assert-Equal $true $installCurrentAndLegacyTaskResult.OtherRunnerStopped "install.ps1 should stop the runner tied to a legacy scheduled task even when the current user-scoped task also exists."
+    Assert-Equal $true $installCurrentAndLegacyTaskResult.OtherAppStopped "install.ps1 should stop the executable tied to a legacy scheduled task even when the current user-scoped task also exists."
 
     $installCleanResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ServiceInstall:$false -SeedStartupShortcut:$false
     Assert-Equal $false $installCleanResult.StartupDirectoryExists "install.ps1 should not create the Startup folder during a plain install without -Service."

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -31,6 +31,8 @@ try {
         }
     )
 
+    $psExe = if (Get-Command "powershell.exe" -ErrorAction SilentlyContinue) { "powershell.exe" } else { "pwsh" }
+
     foreach ($case in $cases) {
         [Environment]::SetEnvironmentVariable($case.EnvironmentName, $case.Directory)
         $payload = [ordered]@{
@@ -44,7 +46,7 @@ try {
         $payload[$case.SessionProperty] = "windows-path-test"
         $json = $payload | ConvertTo-Json -Depth 5 -Compress
 
-        $null = $json | powershell.exe -NoProfile -ExecutionPolicy Bypass -File $case.Script
+        $null = $json | & $psExe -NoProfile -ExecutionPolicy Bypass -File $case.Script
         if ($LASTEXITCODE -ne 0) { throw "$($case.Name) collector failed on first invocation." }
         $jsonl = Get-ChildItem -LiteralPath (Join-Path $case.Directory "usage") -Filter "*.jsonl" -File
         Assert-Equal 1 @($jsonl).Count "$($case.Name) should create one JSONL file."
@@ -52,7 +54,7 @@ try {
         Assert-Equal 1 $entries.Count "$($case.Name) should append the first positive delta."
         Assert-Equal 12 $entries[0].delta_tokens.total "$($case.Name) first delta is wrong."
 
-        $null = $json | powershell.exe -NoProfile -ExecutionPolicy Bypass -File $case.Script
+        $null = $json | & $psExe -NoProfile -ExecutionPolicy Bypass -File $case.Script
         if ($LASTEXITCODE -ne 0) { throw "$($case.Name) collector failed on repeat invocation." }
         $entries = @(Get-Content -LiteralPath $jsonl.FullName | ForEach-Object { $_ | ConvertFrom-Json })
         Assert-Equal 1 $entries.Count "$($case.Name) should not append a zero delta."
@@ -61,7 +63,7 @@ try {
         $payload.context_window.total_output_tokens = 4
         $payload.context_window.total_tokens = 24
         $json = $payload | ConvertTo-Json -Depth 5 -Compress
-        $null = $json | powershell.exe -NoProfile -ExecutionPolicy Bypass -File $case.Script
+        $null = $json | & $psExe -NoProfile -ExecutionPolicy Bypass -File $case.Script
         if ($LASTEXITCODE -ne 0) { throw "$($case.Name) collector failed on delta invocation." }
         $entries = @(Get-Content -LiteralPath $jsonl.FullName | ForEach-Object { $_ | ConvertFrom-Json })
         Assert-Equal 2 $entries.Count "$($case.Name) should append the second positive delta."
@@ -99,6 +101,14 @@ try {
     }
     if (-not $installScriptContent.Contains('return "[$HostAddress]"')) {
         throw "install.ps1 should bracket IPv6 dashboard hosts when printing the URL."
+    }
+    if (-not $installScriptContent.Contains('-AtLogOn -User $env:USERNAME')) {
+        throw "install.ps1 should scope the logon trigger to the current user."
+    }
+    $tryIndex = $installScriptContent.IndexOf('try {')
+    $actionIndex = $installScriptContent.IndexOf('$Action = New-ScheduledTaskAction')
+    if ($tryIndex -lt 0 -or $actionIndex -lt 0 -or $tryIndex -ge $actionIndex) {
+        throw "install.ps1 should define scheduled task action inside the guarded try block."
     }
 
     Write-Host "Windows collector smoke tests passed."

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -13,6 +13,299 @@ function Assert-Equal {
     }
 }
 
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Invoke-GetScriptInstallCapture {
+    param([Nullable[int]]$Port = $null)
+
+    $tempRoot = Join-Path $Root ([guid]::NewGuid())
+    $packageRoot = Join-Path $tempRoot "package"
+    $releaseDir = Join-Path $packageRoot "token-usage-insights-v-test-x86_64-pc-windows-msvc"
+    $capturePath = Join-Path $tempRoot "install-args.json"
+    New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "static") | Out-Null
+
+    Set-Content -LiteralPath (Join-Path $releaseDir "pricing.csv") -Value "model,input,output"
+    $fakeInstallScript = @'
+param(
+    [string]$InstallDir,
+    [string]$BinDir,
+    [string]$HostAddress,
+    [int]$Port,
+    [switch]$Service
+)
+$payload = [ordered]@{
+    Keys = @($PSBoundParameters.Keys | Sort-Object)
+    Port = if ($PSBoundParameters.ContainsKey('Port')) { $Port } else { $null }
+    HostAddress = if ($PSBoundParameters.ContainsKey('HostAddress')) { $HostAddress } else { $null }
+    Service = $PSBoundParameters.ContainsKey('Service')
+}
+$payload | ConvertTo-Json -Compress | Set-Content -LiteralPath '__CAPTURE_PATH__'
+'@.Replace('__CAPTURE_PATH__', $capturePath.Replace("'", "''"))
+    Set-Content -LiteralPath (Join-Path $releaseDir "install.ps1") -Value $fakeInstallScript
+
+    function Invoke-RestMethod { @{ tag_name = "v-test" } }
+    function Invoke-WebRequest {
+        param([string]$Uri, [string]$OutFile)
+        Set-Content -LiteralPath $OutFile -Value "placeholder"
+    }
+    function Expand-Archive {
+        param([string]$Path, [string]$DestinationPath, [switch]$Force)
+        Microsoft.PowerShell.Management\Copy-Item -Recurse -Force $releaseDir (Join-Path $DestinationPath (Split-Path $releaseDir -Leaf))
+    }
+
+    try {
+        $arguments = @{
+            Version = "latest"
+            InstallDir = (Join-Path $tempRoot "install")
+            BinDir = (Join-Path $tempRoot "bin")
+            HostAddress = "127.0.0.1"
+            Service = $true
+        }
+        if ($null -ne $Port) {
+            $arguments["Port"] = $Port
+        }
+
+        & (Join-Path $PSScriptRoot "get.ps1") @arguments
+        Get-Content -Raw -LiteralPath $capturePath | ConvertFrom-Json
+    } finally {
+        Remove-Item Function:\Invoke-RestMethod -ErrorAction SilentlyContinue
+        Remove-Item Function:\Invoke-WebRequest -ErrorAction SilentlyContinue
+        Remove-Item Function:\Expand-Archive -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force
+        }
+    }
+}
+
+function Invoke-InstallServiceTest {
+    param(
+        [string]$HostAddress,
+        [int]$Port,
+        [switch]$FailScheduledTaskAction
+    )
+
+    $tempRoot = Join-Path $Root ([guid]::NewGuid())
+    $releaseDir = Join-Path $tempRoot "release"
+    $scriptDir = Join-Path $releaseDir "scripts"
+    $installDir = Join-Path $tempRoot "installed"
+    $binDir = Join-Path $tempRoot "bin"
+    $previousAppData = $env:APPDATA
+    $previousUsername = $env:USERNAME
+    $env:APPDATA = Join-Path $tempRoot "AppData\Roaming"
+    $env:USERNAME = "test-user"
+
+    New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "static") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "shell") | Out-Null
+    New-Item -ItemType Directory -Force -Path $scriptDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $env:APPDATA | Out-Null
+
+    Set-Content -LiteralPath (Join-Path $releaseDir "token-usage-insights.exe") -Value "binary"
+    Set-Content -LiteralPath (Join-Path $releaseDir "pricing.csv") -Value "model,input,output"
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot "install.ps1") -Destination (Join-Path $scriptDir "install.ps1")
+    Set-Content -LiteralPath (Join-Path $scriptDir "run-service.ps1") -Value "Write-Host 'runner'"
+
+    $global:serviceEvents = New-Object System.Collections.Generic.List[string]
+    $global:hostMessages = New-Object System.Collections.Generic.List[string]
+    $global:runnerProcessAlive = $true
+    $global:appProcessAlive = $true
+    $global:scheduledTaskTriggerUser = $null
+    $runnerCommandLine = "powershell.exe -File `"$installDir\scripts\run-service.ps1`" -InstallDir `"$installDir`""
+
+    function Stop-ScheduledTask {
+        [CmdletBinding()]
+        param([string]$TaskName)
+        $global:serviceEvents.Add("StopScheduledTask")
+    }
+    function Get-CimInstance {
+        [CmdletBinding()]
+        param([string]$ClassName)
+        if ($global:runnerProcessAlive) {
+            return [pscustomobject]@{
+                Name = "powershell.exe"
+                ProcessId = 111
+                CommandLine = $runnerCommandLine
+            }
+        }
+    }
+    function Get-Process {
+        [CmdletBinding()]
+        param([string]$Name, [int]$Id)
+        if ($PSBoundParameters.ContainsKey("Id")) {
+            if (($Id -eq 111) -and $global:runnerProcessAlive) {
+                return [pscustomobject]@{ Id = 111; Name = "powershell" }
+            }
+
+            return
+        }
+
+        if (($Name -eq "token-usage-insights") -and $global:appProcessAlive) {
+            return [pscustomobject]@{ Id = 222; Name = "token-usage-insights" }
+        }
+    }
+    function Stop-Process {
+        [CmdletBinding()]
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [int]$Id,
+            [switch]$Force
+        )
+        process {
+            if ($PSBoundParameters.ContainsKey("Id")) {
+                if ($Id -eq 111) {
+                    $global:runnerProcessAlive = $false
+                    $global:serviceEvents.Add("StopRunner")
+                }
+
+                return
+            }
+
+            if ($InputObject -and $InputObject.Id -eq 222) {
+                $global:appProcessAlive = $false
+                $global:serviceEvents.Add("StopApp")
+            }
+        }
+    }
+    function Copy-Item {
+        [CmdletBinding(DefaultParameterSetName = "Path")]
+        param(
+            [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Path")]
+            [string]$Path,
+            [Parameter(Mandatory = $true, Position = 1, ParameterSetName = "Path")]
+            [string]$Destination,
+            [Parameter(Mandatory = $true, ParameterSetName = "LiteralPath")]
+            [string]$LiteralPath,
+            [Parameter(Mandatory = $true, ParameterSetName = "LiteralPathDestination")]
+            [string]$LiteralDestination,
+            [switch]$Force,
+            [switch]$Recurse
+        )
+
+        $global:serviceEvents.Add("CopyItem")
+        Microsoft.PowerShell.Management\Copy-Item @PSBoundParameters
+    }
+    function New-ScheduledTaskAction {
+        [CmdletBinding()]
+        param([Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs)
+        if ($FailScheduledTaskAction) {
+            throw "Simulated scheduled task action failure."
+        }
+        @{ Action = "ok" }
+    }
+    function New-ScheduledTaskTrigger {
+        [CmdletBinding()]
+        param(
+            [string]$User,
+            [Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs
+        )
+        $global:scheduledTaskTriggerUser = $User
+        @{ Trigger = "ok" }
+    }
+    function New-ScheduledTaskSettingsSet {
+        [CmdletBinding()]
+        param([Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs)
+        @{ Settings = "ok" }
+    }
+    function Register-ScheduledTask {
+        [CmdletBinding()]
+        param(
+            [string]$TaskName,
+            [Parameter(ValueFromRemainingArguments = $true)]$RemainingArgs
+        )
+        $global:serviceEvents.Add("RegisterScheduledTask")
+    }
+    function Start-ScheduledTask {
+        [CmdletBinding()]
+        param([string]$TaskName)
+        $global:serviceEvents.Add("StartScheduledTask")
+    }
+    function Unregister-ScheduledTask {
+        [CmdletBinding()]
+        param([string]$TaskName, [switch]$Confirm)
+        $global:serviceEvents.Add("UnregisterScheduledTask")
+    }
+    function New-Object {
+        [CmdletBinding()]
+        param([string]$ComObject)
+
+        if ($ComObject -eq "WScript.Shell") {
+            $shell = [pscustomobject]@{}
+            $shell | Add-Member -MemberType ScriptMethod -Name CreateShortcut -Value {
+                param([string]$ShortcutPath)
+                $global:serviceEvents.Add("CreateShortcut")
+                $shortcut = [pscustomobject]@{
+                    TargetPath = $null
+                    Arguments = $null
+                    WorkingDirectory = $null
+                    WindowStyle = $null
+                    Description = $null
+                }
+                $shortcut | Add-Member -MemberType ScriptMethod -Name Save -Value {
+                    $global:serviceEvents.Add("SaveShortcut")
+                }
+                return $shortcut
+            }
+            return $shell
+        }
+
+        throw "Unexpected New-Object mock request: $ComObject"
+    }
+    function Start-Process {
+        [CmdletBinding()]
+        param(
+            [string]$FilePath,
+            [string]$ArgumentList,
+            [string]$WorkingDirectory,
+            [string]$WindowStyle
+        )
+        $global:serviceEvents.Add("StartFallbackProcess")
+    }
+    function Write-Host {
+        param([Parameter(ValueFromRemainingArguments = $true)]$Arguments)
+        $global:hostMessages.Add(($Arguments -join " "))
+    }
+
+    try {
+        & (Join-Path $scriptDir "install.ps1") -InstallDir $installDir -BinDir $binDir -HostAddress $HostAddress -Port $Port -Service
+
+        [pscustomobject]@{
+            Events = @($global:serviceEvents)
+            Output = @($global:hostMessages)
+            TriggerUser = $global:scheduledTaskTriggerUser
+        }
+    } finally {
+        foreach ($functionName in @(
+            "Stop-ScheduledTask",
+            "Get-CimInstance",
+            "Get-Process",
+            "Stop-Process",
+            "Copy-Item",
+            "New-ScheduledTaskAction",
+            "New-ScheduledTaskTrigger",
+            "New-ScheduledTaskSettingsSet",
+            "Register-ScheduledTask",
+            "Start-ScheduledTask",
+            "Unregister-ScheduledTask",
+            "New-Object",
+            "Start-Process",
+            "Write-Host"
+        )) {
+            Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
+        }
+        Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, appProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
+        $env:APPDATA = $previousAppData
+        $env:USERNAME = $previousUsername
+
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force
+        }
+    }
+}
+
 try {
     $cases = @(
         @{
@@ -80,36 +373,33 @@ try {
     Assert-Equal $true $getCmd.Parameters.ContainsKey("HostAddress") "get.ps1 should declare -HostAddress."
     Assert-Equal ([Nullable[int]].Name) $getCmd.Parameters["Port"].ParameterType.Name "get.ps1 should allow install.ps1 to keep its own PORT default."
 
+    $capturedInstallArgs = Invoke-GetScriptInstallCapture
+    Assert-Equal $false $capturedInstallArgs.Keys.Contains("Port") "get.ps1 should not pass -Port when the caller omits it."
+    Assert-Equal "127.0.0.1" $capturedInstallArgs.HostAddress "get.ps1 should forward -HostAddress."
+    Assert-Equal $true $capturedInstallArgs.Service "get.ps1 should forward -Service."
+
+    $capturedInstallArgsWithPort = Invoke-GetScriptInstallCapture -Port 3010
+    Assert-Equal 3010 $capturedInstallArgsWithPort.Port "get.ps1 should forward an explicit -Port value."
+
     $runnerCmd = Get-Command (Resolve-Path (Join-Path $PSScriptRoot "run-service.ps1")).Path
     Assert-Equal $true $runnerCmd.Parameters.ContainsKey("InstallDir") "run-service.ps1 should declare -InstallDir."
     Assert-Equal $true $runnerCmd.Parameters.ContainsKey("HostAddress") "run-service.ps1 should declare -HostAddress."
 
-    $getScriptContent = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot "get.ps1")
-    if (-not $getScriptContent.Contains('if ($null -ne $Port) { $InstallArgs["Port"] = $Port }')) {
-        throw "get.ps1 should only forward -Port when explicitly provided."
-    }
+    $installIpv6Result = Invoke-InstallServiceTest -HostAddress "::1" -Port 4010
+    $copyIndex = $installIpv6Result.Events.IndexOf("CopyItem")
+    $stopRunnerIndex = $installIpv6Result.Events.IndexOf("StopRunner")
+    $stopAppIndex = $installIpv6Result.Events.IndexOf("StopApp")
+    Assert-True ($copyIndex -gt $stopRunnerIndex -and $copyIndex -gt $stopAppIndex) "install.ps1 should stop existing service processes before copying files."
+    Assert-True ($installIpv6Result.Output -contains "  http://[::1]:4010") "install.ps1 should bracket IPv6 dashboard URLs."
+    Assert-Equal "test-user" $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
 
-    $installScriptContent = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot "install.ps1")
-    $stopCallIndex = $installScriptContent.IndexOf('Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir')
-    $copyBinaryIndex = $installScriptContent.IndexOf('Copy-Item -Force $BinarySrc (Join-Path $InstallDir "$AppName.exe")')
-    if ($stopCallIndex -lt 0 -or $copyBinaryIndex -lt 0 -or $stopCallIndex -ge $copyBinaryIndex) {
-        throw "install.ps1 should stop an existing service instance before copying the executable."
-    }
+    $installWildcardResult = Invoke-InstallServiceTest -HostAddress "::" -Port 3003
+    Assert-True ($installWildcardResult.Output -contains "  http://localhost:3003") "install.ps1 should print localhost for unspecified IPv6 dashboard URLs."
 
-    if (-not $installScriptContent.Contains('[System.Net.IPAddress]::IPv6Any')) {
-        throw "install.ps1 should detect unspecified IPv6 dashboard hosts."
-    }
-    if (-not $installScriptContent.Contains('return "[$HostAddress]"')) {
-        throw "install.ps1 should bracket IPv6 dashboard hosts when printing the URL."
-    }
-    if (-not $installScriptContent.Contains('-AtLogOn -User $env:USERNAME')) {
-        throw "install.ps1 should scope the logon trigger to the current user."
-    }
-    $tryIndex = $installScriptContent.IndexOf('try {')
-    $actionIndex = $installScriptContent.IndexOf('$Action = New-ScheduledTaskAction')
-    if ($tryIndex -lt 0 -or $actionIndex -lt 0 -or $tryIndex -ge $actionIndex) {
-        throw "install.ps1 should define scheduled task action inside the guarded try block."
-    }
+    $installFallbackResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -FailScheduledTaskAction
+    Assert-True ($installFallbackResult.Events -contains "CreateShortcut") "install.ps1 should create a Startup shortcut when scheduled task registration setup fails."
+    Assert-True ($installFallbackResult.Events -contains "StartFallbackProcess") "install.ps1 should start the fallback background runner when scheduled task setup fails."
+    Assert-True ($installFallbackResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should report Startup folder registration after falling back."
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -76,10 +76,30 @@ try {
     $getCmd = Get-Command (Resolve-Path (Join-Path $PSScriptRoot "get.ps1")).Path
     Assert-Equal $true $getCmd.Parameters.ContainsKey("Service") "get.ps1 should declare -Service."
     Assert-Equal $true $getCmd.Parameters.ContainsKey("HostAddress") "get.ps1 should declare -HostAddress."
+    Assert-Equal ([Nullable[int]].Name) $getCmd.Parameters["Port"].ParameterType.Name "get.ps1 should allow install.ps1 to keep its own PORT default."
 
     $runnerCmd = Get-Command (Resolve-Path (Join-Path $PSScriptRoot "run-service.ps1")).Path
     Assert-Equal $true $runnerCmd.Parameters.ContainsKey("InstallDir") "run-service.ps1 should declare -InstallDir."
     Assert-Equal $true $runnerCmd.Parameters.ContainsKey("HostAddress") "run-service.ps1 should declare -HostAddress."
+
+    $getScriptContent = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot "get.ps1")
+    if (-not $getScriptContent.Contains('if ($null -ne $Port) { $InstallArgs["Port"] = $Port }')) {
+        throw "get.ps1 should only forward -Port when explicitly provided."
+    }
+
+    $installScriptContent = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot "install.ps1")
+    $stopCallIndex = $installScriptContent.IndexOf('Stop-ExistingServiceInstance -TaskName $TaskName -ProcessName $AppName -InstallDir $InstallDir')
+    $copyBinaryIndex = $installScriptContent.IndexOf('Copy-Item -Force $BinarySrc (Join-Path $InstallDir "$AppName.exe")')
+    if ($stopCallIndex -lt 0 -or $copyBinaryIndex -lt 0 -or $stopCallIndex -ge $copyBinaryIndex) {
+        throw "install.ps1 should stop an existing service instance before copying the executable."
+    }
+
+    if (-not $installScriptContent.Contains('[System.Net.IPAddress]::IPv6Any')) {
+        throw "install.ps1 should detect unspecified IPv6 dashboard hosts."
+    }
+    if (-not $installScriptContent.Contains('return "[$HostAddress]"')) {
+        throw "install.ps1 should bracket IPv6 dashboard hosts when printing the URL."
+    }
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -535,7 +535,7 @@ try {
     Assert-True ($installPostRegistrationFailureResult.Events -contains "RegisterScheduledTask") "install.ps1 should still register the scheduled task before a post-registration start failure."
     Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "SaveShortcut") "install.ps1 should not fall back to the Startup shortcut after scheduled task registration succeeds."
     Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "StartFallbackProcess") "install.ps1 should not launch the fallback runner after scheduled task registration succeeds."
-    Assert-True ($installPostRegistrationFailureResult.Output -contains "  Registered task: TokenUsageInsights (Task Scheduler)") "install.ps1 should continue reporting the scheduled task after a post-registration start failure."
+    Assert-True ($installPostRegistrationFailureResult.Output -contains "  Registered task: TokenUsageInsights_test-user (Task Scheduler)") "install.ps1 should continue reporting the scheduled task after a post-registration start failure."
 
     $installWhatIfResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -WhatIf
     Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -50,7 +50,13 @@ $payload | ConvertTo-Json -Compress | Set-Content -LiteralPath '__CAPTURE_PATH__
 
     function Invoke-RestMethod { @{ tag_name = "v-test" } }
     function Invoke-WebRequest {
-        param([string]$Uri, [string]$OutFile)
+        param(
+            [string]$Uri,
+            [string]$OutFile,
+            [switch]$UseBasicParsing,
+            [parameter(ValueFromRemainingArguments = $true)]
+            $RemainingArgs
+        )
         Set-Content -LiteralPath $OutFile -Value "placeholder"
     }
     function Expand-Archive {
@@ -88,7 +94,8 @@ function Invoke-InstallServiceTest {
         [int]$Port,
         [switch]$FailScheduledTaskAction,
         [switch]$FailStartScheduledTask,
-        [switch]$WhatIf
+        [switch]$WhatIf,
+        [switch]$ExistingTaskInOtherDir
     )
 
     $tempRoot = Join-Path $Root ([guid]::NewGuid())
@@ -127,6 +134,24 @@ function Invoke-InstallServiceTest {
     $otherRunnerCommandLine = "powershell.exe -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
     $appExecutablePath = "$installDir\token-usage-insights.exe"
     $otherAppExecutablePath = "$otherInstallDir\token-usage-insights.exe"
+
+    function Get-ScheduledTask {
+        [CmdletBinding()]
+        param([string]$TaskName)
+        if ($ExistingTaskInOtherDir) {
+            return [pscustomobject]@{
+                TaskName = $TaskName
+                Actions = @(
+                    [pscustomobject]@{
+                        Execute = "powershell.exe"
+                        Argument = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
+                        WorkingDirectory = $otherInstallDir
+                    }
+                )
+            }
+        }
+        return $null
+    }
 
     function Stop-ScheduledTask {
         [CmdletBinding()]
@@ -345,6 +370,7 @@ function Invoke-InstallServiceTest {
         }
     } finally {
         foreach ($functionName in @(
+            "Get-ScheduledTask",
             "Stop-ScheduledTask",
             "Get-CimInstance",
             "Get-Process",
@@ -476,13 +502,13 @@ try {
     Assert-True ($installWildcardResult.Output -contains "  http://localhost:3003") "install.ps1 should print localhost for unspecified IPv6 dashboard URLs."
 
     $installFallbackResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -FailScheduledTaskAction
-    Assert-True ($installFallbackResult.Events -contains "CreateShortcut") "install.ps1 should create a Startup shortcut when scheduled task registration setup fails."
+    Assert-True ($installFallbackResult.Events -contains "SaveShortcut") "install.ps1 should create a Startup shortcut when scheduled task registration setup fails."
     Assert-True ($installFallbackResult.Events -contains "StartFallbackProcess") "install.ps1 should start the fallback background runner when scheduled task setup fails."
     Assert-True ($installFallbackResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should report Startup folder registration after falling back."
 
     $installPostRegistrationFailureResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -FailStartScheduledTask
     Assert-True ($installPostRegistrationFailureResult.Events -contains "RegisterScheduledTask") "install.ps1 should still register the scheduled task before a post-registration start failure."
-    Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "CreateShortcut") "install.ps1 should not fall back to the Startup shortcut after scheduled task registration succeeds."
+    Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "SaveShortcut") "install.ps1 should not fall back to the Startup shortcut after scheduled task registration succeeds."
     Assert-Equal $false ($installPostRegistrationFailureResult.Events -contains "StartFallbackProcess") "install.ps1 should not launch the fallback runner after scheduled task registration succeeds."
     Assert-True ($installPostRegistrationFailureResult.Output -contains "  Registered task: TokenUsageInsights (Task Scheduler)") "install.ps1 should continue reporting the scheduled task after a post-registration start failure."
 
@@ -490,6 +516,10 @@ try {
     Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."
     Assert-Equal $false ($installWhatIfResult.Output -contains "Token 戰情室 installed.") "install.ps1 should not output completion message during -WhatIf."
     Assert-Equal $false ($installWhatIfResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should not report service registration during -WhatIf."
+
+    $installCrossDirectoryResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -ExistingTaskInOtherDir
+    Assert-Equal $true $installCrossDirectoryResult.OtherRunnerStopped "install.ps1 should stop a previous runner when existing scheduled task pointed to a different directory."
+    Assert-Equal $true $installCrossDirectoryResult.OtherAppStopped "install.ps1 should stop a previous app process when existing scheduled task pointed to a different directory."
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -460,7 +460,17 @@ try {
     Assert-Equal $false $installIpv6Result.OtherRunnerStopped "install.ps1 should not stop a different runner whose install path merely shares a prefix."
     Assert-Equal $false $installIpv6Result.OtherAppStopped "install.ps1 should not stop a different installed executable whose path merely shares a prefix."
     Assert-True ($installIpv6Result.Output -contains "  http://[::1]:4010") "install.ps1 should bracket IPv6 dashboard URLs."
-    Assert-Equal "test-domain\test-user" $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
+    $expectedTriggerUser = try {
+        $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        if ($identity -and $identity.Name) {
+            $identity.Name
+        } else {
+            "test-domain\test-user"
+        }
+    } catch {
+        "test-domain\test-user"
+    }
+    Assert-Equal $expectedTriggerUser $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
 
     $installWildcardResult = Invoke-InstallServiceTest -HostAddress "::" -Port 3003
     Assert-True ($installWildcardResult.Output -contains "  http://localhost:3003") "install.ps1 should print localhost for unspecified IPv6 dashboard URLs."
@@ -478,6 +488,8 @@ try {
 
     $installWhatIfResult = Invoke-InstallServiceTest -HostAddress "127.0.0.1" -Port 3003 -WhatIf
     Assert-Equal $true $installWhatIfResult.StartupShortcutExists "install.ps1 should not remove an existing Startup shortcut during -WhatIf."
+    Assert-Equal $false ($installWhatIfResult.Output -contains "Token 戰情室 installed.") "install.ps1 should not output completion message during -WhatIf."
+    Assert-Equal $false ($installWhatIfResult.Output -contains "  Registered in:   Startup folder") "install.ps1 should not report service registration during -WhatIf."
 
     Write-Host "Windows collector smoke tests passed."
 } finally {

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -96,8 +96,10 @@ function Invoke-InstallServiceTest {
     $binDir = Join-Path $tempRoot "bin"
     $previousAppData = $env:APPDATA
     $previousUsername = $env:USERNAME
+    $previousUserDomain = $env:USERDOMAIN
     $env:APPDATA = Join-Path $tempRoot "AppData\Roaming"
     $env:USERNAME = "test-user"
+    $env:USERDOMAIN = "test-domain"
 
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "static") | Out-Null
     New-Item -ItemType Directory -Force -Path (Join-Path $releaseDir "shell") | Out-Null
@@ -299,6 +301,7 @@ function Invoke-InstallServiceTest {
         Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, appProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
         $env:APPDATA = $previousAppData
         $env:USERNAME = $previousUsername
+        $env:USERDOMAIN = $previousUserDomain
 
         if (Test-Path -LiteralPath $tempRoot) {
             Remove-Item -LiteralPath $tempRoot -Recurse -Force
@@ -391,7 +394,7 @@ try {
     $stopAppIndex = $installIpv6Result.Events.IndexOf("StopApp")
     Assert-True ($copyIndex -gt $stopRunnerIndex -and $copyIndex -gt $stopAppIndex) "install.ps1 should stop existing service processes before copying files."
     Assert-True ($installIpv6Result.Output -contains "  http://[::1]:4010") "install.ps1 should bracket IPv6 dashboard URLs."
-    Assert-Equal "test-user" $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
+    Assert-Equal "test-domain\test-user" $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
 
     $installWildcardResult = Invoke-InstallServiceTest -HostAddress "::" -Port 3003
     Assert-True ($installWildcardResult.Output -contains "  http://localhost:3003") "install.ps1 should print localhost for unspecified IPv6 dashboard URLs."

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -114,9 +114,12 @@ function Invoke-InstallServiceTest {
     $global:serviceEvents = New-Object System.Collections.Generic.List[string]
     $global:hostMessages = New-Object System.Collections.Generic.List[string]
     $global:runnerProcessAlive = $true
+    $global:otherRunnerProcessAlive = $true
     $global:appProcessAlive = $true
     $global:scheduledTaskTriggerUser = $null
     $runnerCommandLine = "powershell.exe -File `"$installDir\scripts\run-service.ps1`" -InstallDir `"$installDir`""
+    $otherInstallDir = "$installDir-old"
+    $otherRunnerCommandLine = "powershell.exe -File `"$otherInstallDir\scripts\run-service.ps1`" -InstallDir `"$otherInstallDir`""
 
     function Stop-ScheduledTask {
         [CmdletBinding()]
@@ -126,13 +129,22 @@ function Invoke-InstallServiceTest {
     function Get-CimInstance {
         [CmdletBinding()]
         param([string]$ClassName)
+        $processes = @()
         if ($global:runnerProcessAlive) {
-            return [pscustomobject]@{
+            $processes += [pscustomobject]@{
                 Name = "powershell.exe"
                 ProcessId = 111
                 CommandLine = $runnerCommandLine
             }
         }
+        if ($global:otherRunnerProcessAlive) {
+            $processes += [pscustomobject]@{
+                Name = "powershell.exe"
+                ProcessId = 112
+                CommandLine = $otherRunnerCommandLine
+            }
+        }
+        return $processes
     }
     function Get-Process {
         [CmdletBinding()]
@@ -140,6 +152,9 @@ function Invoke-InstallServiceTest {
         if ($PSBoundParameters.ContainsKey("Id")) {
             if (($Id -eq 111) -and $global:runnerProcessAlive) {
                 return [pscustomobject]@{ Id = 111; Name = "powershell" }
+            }
+            if (($Id -eq 112) -and $global:otherRunnerProcessAlive) {
+                return [pscustomobject]@{ Id = 112; Name = "powershell" }
             }
 
             return
@@ -161,6 +176,10 @@ function Invoke-InstallServiceTest {
                 if ($Id -eq 111) {
                     $global:runnerProcessAlive = $false
                     $global:serviceEvents.Add("StopRunner")
+                }
+                if ($Id -eq 112) {
+                    $global:otherRunnerProcessAlive = $false
+                    $global:serviceEvents.Add("StopOtherRunner")
                 }
 
                 return
@@ -278,6 +297,7 @@ function Invoke-InstallServiceTest {
             Events = @($global:serviceEvents)
             Output = @($global:hostMessages)
             TriggerUser = $global:scheduledTaskTriggerUser
+            OtherRunnerStopped = (-not $global:otherRunnerProcessAlive)
         }
     } finally {
         foreach ($functionName in @(
@@ -298,7 +318,7 @@ function Invoke-InstallServiceTest {
         )) {
             Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
         }
-        Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, appProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable serviceEvents, hostMessages, runnerProcessAlive, otherRunnerProcessAlive, appProcessAlive, scheduledTaskTriggerUser -Scope Global -ErrorAction SilentlyContinue
         $env:APPDATA = $previousAppData
         $env:USERNAME = $previousUsername
         $env:USERDOMAIN = $previousUserDomain
@@ -393,6 +413,7 @@ try {
     $stopRunnerIndex = $installIpv6Result.Events.IndexOf("StopRunner")
     $stopAppIndex = $installIpv6Result.Events.IndexOf("StopApp")
     Assert-True ($copyIndex -gt $stopRunnerIndex -and $copyIndex -gt $stopAppIndex) "install.ps1 should stop existing service processes before copying files."
+    Assert-Equal $false $installIpv6Result.OtherRunnerStopped "install.ps1 should not stop a different runner whose install path merely shares a prefix."
     Assert-True ($installIpv6Result.Output -contains "  http://[::1]:4010") "install.ps1 should bracket IPv6 dashboard URLs."
     Assert-Equal "test-domain\test-user" $installIpv6Result.TriggerUser "install.ps1 should scope the logon trigger to the current user."
 


### PR DESCRIPTION
Closes #50

## 摘要 (Summary)

為 Windows 平台提供與 Linux（systemd）和 macOS（launchd）對等的常駐服務安裝功能。讓 Windows 使用者能透過工作排程器（Task Scheduler）或啟動資料夾在登入時自動於背景啟動 Token 戰情室，不再需要手動維持終端機視窗開啟。

### 主要變更
1. **`scripts/install.ps1`**：
   - 新增 `-Service` 與 `-HostAddress` 參數。
   - 優先使用 Windows 工作排程器（`Register-ScheduledTask`）註冊登入自啟動工作（`-AtLogOn`），設定筆電電池供電不中止且持續執行。
   - 支援重複安裝：自動安全停止舊有排程與舊同名行程，安裝後立即啟動。
   - 若 Task Scheduler 權限受限，自動回退至使用者啟動資料夾（`shell:startup`）建立捷徑。
   - 更新安裝完成輸出，顯示常駐服務註冊狀態、日誌目錄與儀表板 URL。
2. **`scripts/run-service.ps1`**：
   - Windows 背景服務專用啟動腳本，設定環境變數 `PORT` 與 `HOST`。
   - 透過 `Start-Process -WindowStyle Hidden` 啟動主程式，消除終端機黑視窗彈出。
   - 自動將 stdout 與 stderr 輸出至 `logs\token-usage-insights.out.log` 與 `logs\token-usage-insights.err.log`。
   - 包含進程生命週期管理與例外回收處理。
3. **`scripts/get.ps1`**：
   - 新增 `-Service` 與 `-HostAddress` 參數並透傳給 `install.ps1`，支援一行指令完成常駐安裝。
4. **自動化測試與工作流程**：
   - `scripts/test-windows.ps1`：新增對 `install.ps1`、`get.ps1` 與 `run-service.ps1` 參數介面的斷言檢驗。
   - `.github/workflows/release.yml`：將 `run-service.ps1` 納入 PowerShell AST 語法檢查流程。
5. **說明文件同步**：
   - 同步更新正體中文（`README.md`）、英文（`README.en.md`）、日文（`README.ja.md`）、韓文（`README.ko.md`）與簡體中文（`README.zh-CN.md`），提供完整的 Windows 常駐服務安裝與管理（狀態、日誌、重啟、停止、解除安裝）指令。

## 驗證項目 (Testing)
- [x] `pwsh` AST 剖析：`scripts/install.ps1`、`scripts/get.ps1`、`scripts/run-service.ps1`、`scripts/test-windows.ps1` 均通過語法驗證（0 errors）
- [x] `scripts/test-windows.ps1`：參數綁定斷言測試全部通過
- [x] Shell 腳本檢查：`bash -n scripts/install.sh` 與 `bash -n scripts/get.sh` 通過
- [x] `npm test`：10 項測試全部通過
- [x] `cargo fmt --check`：通過
- [x] `cargo test`：228 項測試全數通過
- [x] `cargo clippy --all-targets --all-features`：零警告零錯誤通過
- [x] `cargo build --release`：二進位檔編譯通過，零警告零錯誤